### PR TITLE
fix: run demo bootstrap script correctly in deploy pipeline

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -49,11 +49,11 @@ done
 echo "▶ Bootstrapping demo user..."
 docker run --rm \
     --network "$(docker network ls --filter name=tortoise --format '{{.Name}}' | head -1)" \
-    -e API_URL=http://track-api:8080/api \
+    -v "$APP_DIR/tracker-simulator:/app/tracker-simulator" \
+    -e API_URL=http://tortoise-track-api:8080/api \
     -w /app/tracker-simulator \
     node:22-alpine \
-    sh -c "npm install --silent && node setup.js" 2>/dev/null || \
-    API_URL=https://tortoisegps.didtor.dev/api node "$APP_DIR/tracker-simulator/setup.js"
+    sh -c "npm install --silent && node setup.js"
 
 # ── 6. Status ───────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

Fixes the post-deploy bootstrap step that creates the demo user and assigns the trackers.
The script was attempting to run `node setup.js` inside an ephemeral container, but the source code was not mounted, causing a `file not found` error. The fallback attempted to run `node` on the host, which is not installed.

## Changes
- Mount the `tracker-simulator` directory into the ephemeral Node container
- Point `API_URL` to the correct Docker Compose service name (`tortoise-track-api`)
- Remove the host node fallback