### PR TITLE
fix(test): add fallback jwt secret for vitest

### DIFF
--- a/track-api/test/setup.js
+++ b/track-api/test/setup.js
@@ -1,4 +1,5 @@
 require('dotenv').config()
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-jwt-secret'
 const { MongoMemoryServer } = require('mongodb-memory-server')
 const { mongoose } = require('track-data')
 


### PR DESCRIPTION
Closes #57

### PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

### Summary
- Added fallback value for `process.env.JWT_SECRET` in Vitest setup
- Prevents missing secret errors in GitHub Actions CI where `.env` is unavailable

### Changes
| File | Change |
|------|--------|
| `track-api/test/setup.js` | Added `process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-jwt-secret'` |

### Test Plan
- [x] Scripts run without errors
- [x] Manually tested the affected functionality

### Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts
- [x] Skills tested in at least one agent
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers