### PR TITLE
fix(deploy): prevent self-updating bash script from crashing

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # deploy/deploy.sh — Deploy or update TorToise GPS
 # Run from the repo root: bash deploy/deploy.sh
+{
 set -euo pipefail
 
 APP_DIR="/opt/tortoise-gps"
@@ -66,3 +67,4 @@ echo "  🌐  https://tortoisegps.didtor.dev"
 echo "  📡  GPS TCP: 204.168.227.78:5000"
 echo "  🔑  livedemo@example.com / LiveDemo"
 echo "══════════════════════════════════════════"
+}


### PR DESCRIPTION
Closes #59

### PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

### Summary
- Wrapped `deploy.sh` contents in a `{ ... }` block to force full file buffering into memory before execution.
- Prevents weird parsing crashes caused by `git reset --hard` modifying the script file while `bash` is executing it line by line.

### Changes
| File | Change |
|------|--------|
| `deploy/deploy.sh` | Added `{` at the start and `}` at the end |

### Test Plan
- [x] Scripts run without errors
- [x] Manually tested the affected functionality

### Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts
- [x] Skills tested in at least one agent
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers