### PR TITLE
feat(backoffice): visual editor for permissions and features

### DIFF
--- a/track-app/src/components/Backoffice/access-catalog.ts
+++ b/track-app/src/components/Backoffice/access-catalog.ts
@@ -1,0 +1,67 @@
+export const FEATURE_KEYS = [
+  'tracking',
+  'fleet',
+  'poi',
+  'backoffice'
+]
+
+export const PERMISSION_KEYS = [
+  'tracking.read',
+  'fleet.read',
+  'fleet.create',
+  'fleet.update',
+  'fleet.delete',
+  'poi.read',
+  'poi.create',
+  'poi.update',
+  'poi.delete',
+  'companies.read',
+  'companies.create',
+  'companies.update',
+  'users.read',
+  'users.create',
+  'users.update',
+  'users.delete'
+]
+
+const ROLE_PERMISSION_TEMPLATE: Record<string, string[]> = {
+  staff: [...PERMISSION_KEYS],
+  owner: [
+    'tracking.read',
+    'fleet.read',
+    'fleet.create',
+    'fleet.update',
+    'fleet.delete',
+    'poi.read',
+    'poi.create',
+    'poi.update',
+    'poi.delete'
+  ],
+  admin: [
+    'tracking.read',
+    'fleet.read',
+    'fleet.create',
+    'fleet.update',
+    'fleet.delete',
+    'poi.read',
+    'poi.create',
+    'poi.update',
+    'poi.delete'
+  ],
+  dispatcher: [
+    'tracking.read',
+    'fleet.read',
+    'fleet.create',
+    'fleet.update',
+    'poi.read'
+  ],
+  viewer: [
+    'tracking.read',
+    'fleet.read',
+    'poi.read'
+  ]
+}
+
+export function permissionTemplateForRole(role: string): string[] {
+  return [...(ROLE_PERMISSION_TEMPLATE[role] || ROLE_PERMISSION_TEMPLATE.viewer)]
+}

--- a/track-app/src/components/Backoffice/index.tsx
+++ b/track-app/src/components/Backoffice/index.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react'
 import PageShell from '../shared/PageShell'
 import DataTable, { Column } from '../shared/DataTable'
 import { useBackoffice, BackofficeCompany, BackofficeUser } from '../../hooks/useBackoffice'
+import { FEATURE_KEYS, PERMISSION_KEYS, permissionTemplateForRole } from './access-catalog'
 
 const COMPANY_COLUMNS: Column<BackofficeCompany>[] = [
   { key: 'name', label: 'Name' },
@@ -38,9 +39,20 @@ function splitCsv(input: string): string[] {
     .filter(Boolean)
 }
 
+function toggleInArray(list: string[], value: string): string[] {
+  return list.includes(value)
+    ? list.filter(item => item !== value)
+    : [...list, value]
+}
+
 function Backoffice() {
-  const { companies, users, loading, createCompany, createUser } = useBackoffice()
-  const [companyForm, setCompanyForm] = useState({ name: '', slug: '', active: true, featureKeysCsv: '' })
+  const { companies, users, loading, createCompany, createUser, updateCompany, updateUser } = useBackoffice()
+  const [companyForm, setCompanyForm] = useState({
+    name: '',
+    slug: '',
+    active: true,
+    featureKeys: [...FEATURE_KEYS]
+  })
   const [userForm, setUserForm] = useState({
     name: '',
     surname: '',
@@ -48,8 +60,10 @@ function Backoffice() {
     password: '',
     role: 'admin',
     companyId: '',
-    permissionKeysCsv: ''
+    permissionKeys: permissionTemplateForRole('admin')
   })
+  const [selectedCompanyId, setSelectedCompanyId] = useState<string>('')
+  const [selectedUserId, setSelectedUserId] = useState<string>('')
 
   const companyOptions = useMemo(
     () => companies.map((company) => ({ id: company.id, label: `${company.name} (${company.slug})` })),
@@ -58,13 +72,13 @@ function Backoffice() {
 
   const onCreateCompany = async (e: React.FormEvent) => {
     e.preventDefault()
-    await createCompany(
-      companyForm.name,
-      companyForm.slug,
-      companyForm.active,
-      splitCsv(companyForm.featureKeysCsv)
-    )
-    setCompanyForm({ name: '', slug: '', active: true, featureKeysCsv: '' })
+    await createCompany(companyForm.name, companyForm.slug, companyForm.active, companyForm.featureKeys)
+    setCompanyForm({
+      name: '',
+      slug: '',
+      active: true,
+      featureKeys: [...FEATURE_KEYS]
+    })
   }
 
   const onCreateUser = async (e: React.FormEvent) => {
@@ -76,7 +90,7 @@ function Backoffice() {
       password: userForm.password,
       role: userForm.role,
       companyId: userForm.companyId,
-      permissionKeys: splitCsv(userForm.permissionKeysCsv)
+      permissionKeys: userForm.permissionKeys
     })
     setUserForm({
       name: '',
@@ -85,7 +99,78 @@ function Backoffice() {
       password: '',
       role: 'admin',
       companyId: '',
-      permissionKeysCsv: ''
+      permissionKeys: permissionTemplateForRole('admin')
+    })
+  }
+
+  const selectedCompany = useMemo(
+    () => companies.find(company => company.id === selectedCompanyId) || null,
+    [companies, selectedCompanyId]
+  )
+
+  const selectedUser = useMemo(
+    () => users.find(user => user.id === selectedUserId) || null,
+    [users, selectedUserId]
+  )
+
+  const [companyEdit, setCompanyEdit] = useState({
+    name: '',
+    slug: '',
+    active: true,
+    featureKeys: [] as string[]
+  })
+
+  const [userEdit, setUserEdit] = useState({
+    name: '',
+    surname: '',
+    email: '',
+    role: 'viewer',
+    companyId: '',
+    permissionKeys: [] as string[]
+  })
+
+  const onPickCompany = (companyId: string) => {
+    setSelectedCompanyId(companyId)
+    const company = companies.find(item => item.id === companyId)
+    if (!company) return
+    setCompanyEdit({
+      name: company.name,
+      slug: company.slug,
+      active: company.active,
+      featureKeys: [...company.featureKeys]
+    })
+  }
+
+  const onPickUser = (userId: string) => {
+    setSelectedUserId(userId)
+    const user = users.find(item => item.id === userId)
+    if (!user) return
+    setUserEdit({
+      name: user.name,
+      surname: user.surname,
+      email: user.email,
+      role: user.role,
+      companyId: user.companyId || '',
+      permissionKeys: [...user.permissionKeys]
+    })
+  }
+
+  const onUpdateCompany = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!selectedCompany) return
+    await updateCompany(selectedCompany.id, companyEdit.name, companyEdit.slug, companyEdit.active, companyEdit.featureKeys)
+  }
+
+  const onUpdateUser = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!selectedUser) return
+    await updateUser(selectedUser.id, {
+      name: userEdit.name,
+      surname: userEdit.surname,
+      email: userEdit.email,
+      role: userEdit.role,
+      companyId: userEdit.companyId || undefined,
+      permissionKeys: userEdit.permissionKeys
     })
   }
 
@@ -116,14 +201,19 @@ function Backoffice() {
             </label>
           </div>
           <div className="field">
-            <label className="label">Feature keys (csv)</label>
+            <label className="label">Features</label>
             <div className="control">
-              <input
-                className="input"
-                placeholder="tracking,fleet,poi,backoffice"
-                value={companyForm.featureKeysCsv}
-                onChange={(e) => setCompanyForm(prev => ({ ...prev, featureKeysCsv: e.target.value }))}
-              />
+              {FEATURE_KEYS.map((feature) => (
+                <label key={feature} className="checkbox mr-4" style={{ display: 'inline-block' }}>
+                  <input
+                    type="checkbox"
+                    checked={companyForm.featureKeys.includes(feature)}
+                    onChange={() => setCompanyForm(prev => ({ ...prev, featureKeys: toggleInArray(prev.featureKeys, feature) }))}
+                  />
+                  {' '}
+                  {feature}
+                </label>
+              ))}
             </div>
           </div>
           <button className="button is-warning is-rounded" type="submit">Create Company</button>
@@ -158,7 +248,13 @@ function Backoffice() {
             <div className="column is-6">
               <label className="label">Role</label>
               <div className="select is-fullwidth">
-                <select value={userForm.role} onChange={(e) => setUserForm(prev => ({ ...prev, role: e.target.value }))}>
+                <select
+                  value={userForm.role}
+                  onChange={(e) => {
+                    const role = e.target.value
+                    setUserForm(prev => ({ ...prev, role, permissionKeys: permissionTemplateForRole(role) }))
+                  }}
+                >
                   <option value="staff">staff</option>
                   <option value="owner">owner</option>
                   <option value="admin">admin</option>
@@ -179,17 +275,154 @@ function Backoffice() {
               </div>
             </div>
             <div className="column is-12">
-              <label className="label">Permission keys (csv)</label>
-              <input
-                className="input"
-                placeholder="tracking.read,fleet.read,fleet.create"
-                value={userForm.permissionKeysCsv}
-                onChange={(e) => setUserForm(prev => ({ ...prev, permissionKeysCsv: e.target.value }))}
-              />
+              <label className="label">Permissions</label>
+              <div>
+                {PERMISSION_KEYS.map((permission) => (
+                  <label key={permission} className="checkbox mr-4" style={{ display: 'inline-block' }}>
+                    <input
+                      type="checkbox"
+                      checked={userForm.permissionKeys.includes(permission)}
+                      onChange={() => setUserForm(prev => ({ ...prev, permissionKeys: toggleInArray(prev.permissionKeys, permission) }))}
+                    />
+                    {' '}
+                    {permission}
+                  </label>
+                ))}
+              </div>
             </div>
           </div>
           <button className="button is-warning is-rounded" type="submit">Create User</button>
         </form>
+      </section>
+
+      <section style={{ marginBottom: 24 }}>
+        <h3 className="title is-5">Edit Company</h3>
+        <div className="field">
+          <label className="label">Company</label>
+          <div className="select is-fullwidth">
+            <select value={selectedCompanyId} onChange={(e) => onPickCompany(e.target.value)}>
+              <option value="">Select company</option>
+              {companyOptions.map((company) => (
+                <option key={company.id} value={company.id}>{company.label}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+        {selectedCompany && (
+          <form onSubmit={onUpdateCompany}>
+            <div className="field">
+              <label className="label">Name</label>
+              <input className="input" value={companyEdit.name} onChange={(e) => setCompanyEdit(prev => ({ ...prev, name: e.target.value }))} required />
+            </div>
+            <div className="field">
+              <label className="label">Slug</label>
+              <input className="input" value={companyEdit.slug} onChange={(e) => setCompanyEdit(prev => ({ ...prev, slug: e.target.value }))} required />
+            </div>
+            <div className="field">
+              <label className="checkbox">
+                <input type="checkbox" checked={companyEdit.active} onChange={(e) => setCompanyEdit(prev => ({ ...prev, active: e.target.checked }))} />
+                {' '}
+                Active
+              </label>
+            </div>
+            <div className="field">
+              <label className="label">Features</label>
+              <div>
+                {FEATURE_KEYS.map((feature) => (
+                  <label key={feature} className="checkbox mr-4" style={{ display: 'inline-block' }}>
+                    <input
+                      type="checkbox"
+                      checked={companyEdit.featureKeys.includes(feature)}
+                      onChange={() => setCompanyEdit(prev => ({ ...prev, featureKeys: toggleInArray(prev.featureKeys, feature) }))}
+                    />
+                    {' '}
+                    {feature}
+                  </label>
+                ))}
+              </div>
+            </div>
+            <button className="button is-warning is-rounded" type="submit">Update Company</button>
+          </form>
+        )}
+      </section>
+
+      <section style={{ marginBottom: 24 }}>
+        <h3 className="title is-5">Edit User</h3>
+        <div className="field">
+          <label className="label">User</label>
+          <div className="select is-fullwidth">
+            <select value={selectedUserId} onChange={(e) => onPickUser(e.target.value)}>
+              <option value="">Select user</option>
+              {users.map((user) => (
+                <option key={user.id} value={user.id}>{user.email}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+        {selectedUser && (
+          <form onSubmit={onUpdateUser}>
+            <div className="columns is-multiline">
+              <div className="column is-6">
+                <label className="label">Name</label>
+                <input className="input" value={userEdit.name} onChange={(e) => setUserEdit(prev => ({ ...prev, name: e.target.value }))} required />
+              </div>
+              <div className="column is-6">
+                <label className="label">Surname</label>
+                <input className="input" value={userEdit.surname} onChange={(e) => setUserEdit(prev => ({ ...prev, surname: e.target.value }))} required />
+              </div>
+              <div className="column is-6">
+                <label className="label">Email</label>
+                <input className="input" type="email" value={userEdit.email} onChange={(e) => setUserEdit(prev => ({ ...prev, email: e.target.value }))} required />
+              </div>
+              <div className="column is-6">
+                <label className="label">Role</label>
+                <div className="select is-fullwidth">
+                  <select
+                    value={userEdit.role}
+                    onChange={(e) => {
+                      const role = e.target.value
+                      setUserEdit(prev => ({ ...prev, role, permissionKeys: permissionTemplateForRole(role) }))
+                    }}
+                  >
+                    <option value="staff">staff</option>
+                    <option value="owner">owner</option>
+                    <option value="admin">admin</option>
+                    <option value="dispatcher">dispatcher</option>
+                    <option value="viewer">viewer</option>
+                  </select>
+                </div>
+              </div>
+              <div className="column is-6">
+                <label className="label">Company</label>
+                <div className="select is-fullwidth">
+                  <select value={userEdit.companyId} onChange={(e) => setUserEdit(prev => ({ ...prev, companyId: e.target.value }))}>
+                    <option value="">Select company</option>
+                    {companyOptions.map((company) => (
+                      <option key={company.id} value={company.id}>{company.label}</option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              <div className="column is-12">
+                <label className="label">Permissions</label>
+                <div>
+                  {PERMISSION_KEYS.map((permission) => (
+                    <label key={permission} className="checkbox mr-4" style={{ display: 'inline-block' }}>
+                      <input
+                        type="checkbox"
+                        checked={userEdit.permissionKeys.includes(permission)}
+                        onChange={() => setUserEdit(prev => ({ ...prev, permissionKeys: toggleInArray(prev.permissionKeys, permission) }))}
+                      />
+                      {' '}
+                      {permission}
+                    </label>
+                  ))}
+                </div>
+              </div>
+            </div>
+            <button className="button is-warning is-rounded" type="submit">Update User</button>
+          </form>
+        )}
       </section>
 
       <section>


### PR DESCRIPTION
Summary:\n- replace CSV-based permissions/features input with checkbox-based UI\n- add role templates to prefill permission sets\n- add edit forms for existing companies and users\n\nNotes:\n- this PR is stacked on top of #71 and should be merged after it\n\nValidation:\n- npm run -w track-app typecheck