### PR TITLE
feat(trackers): alias column, status LED and map focus action

### DIFF
--- a/track-app/src/components/Home/index.tsx
+++ b/track-app/src/components/Home/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react'
+import { useLocation } from 'react-router-dom'
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
 import './index.sass'
@@ -10,6 +11,7 @@ interface HomeProps {
 
 function Home({ darkmode }: HomeProps) {
   const { pois, trackers, livePositions, deletePOI, deleteTracker, goToDetail } = useLiveTracks()
+  const location = useLocation()
 
   const mapRef = useRef<L.Map | null>(null)
   const poiMarkRef = useRef<L.Marker[]>([])
@@ -17,6 +19,7 @@ function Home({ darkmode }: HomeProps) {
   const truckMarkRef = useRef<Map<string, L.Marker>>(new Map())
   const tileLightRef = useRef<L.TileLayer | null>(null)
   const tileDarkRef = useRef<L.TileLayer | null>(null)
+  const lastFocusedSerialRef = useRef<string | null>(null)
 
   // ── helpers ──────────────────────────────────────────────────────────────
 
@@ -104,6 +107,19 @@ function Home({ darkmode }: HomeProps) {
     })
   }
 
+  const focusTrackerIfRequested = () => {
+    const focusSerial = (location.state as { focusSerial?: string } | null)?.focusSerial
+    if (!focusSerial || !mapRef.current) return
+    if (lastFocusedSerialRef.current === focusSerial) return
+
+    const marker = truckMarkRef.current.get(focusSerial)
+    if (!marker) return
+
+    mapRef.current.setView(marker.getLatLng(), Math.max(mapRef.current.getZoom(), 13), { animate: true })
+    marker.openPopup()
+    lastFocusedSerialRef.current = focusSerial
+  }
+
   const initMap = (initialPois: HomePoi[]) => {
     if (mapRef.current) return
 
@@ -161,6 +177,7 @@ function Home({ darkmode }: HomeProps) {
   useEffect(() => {
     if (!mapRef.current || !livePositions.length) return
     upsertTruckMarkers(livePositions)
+    focusTrackerIfRequested()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [livePositions])
 
@@ -170,8 +187,14 @@ function Home({ darkmode }: HomeProps) {
     // Only paint trackers that don't have a live position yet
     const unknown = trackers.filter(t => !truckMarkRef.current.has(t.serialNumber))
     if (unknown.length) upsertTruckMarkers(unknown)
+    focusTrackerIfRequested()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [trackers])
+
+  useEffect(() => {
+    focusTrackerIfRequested()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.state])
 
   // React to darkmode changes: swap tile layers without reinitializing the map
   useEffect(() => {

--- a/track-app/src/components/Trackings/New.tsx
+++ b/track-app/src/components/Trackings/New.tsx
@@ -32,13 +32,13 @@ function TrackingsNew() {
         </div>
 
         <div className="field">
-          <label className="label">License Plate <span className="has-text-grey is-size-7">(optional)</span></label>
+          <label className="label">Alias <span className="has-text-grey is-size-7">(optional)</span></label>
           <div className="control">
             <input
               className="input is-rounded is-warning"
               type="text"
               name="licensePlate"
-              placeholder="1234-ABC-001"
+              placeholder="Truck Madrid 01"
             />
           </div>
         </div>

--- a/track-app/src/components/Trackings/index.tsx
+++ b/track-app/src/components/Trackings/index.tsx
@@ -4,18 +4,63 @@ import PageShell from '../shared/PageShell'
 import DataTable, { Column } from '../shared/DataTable'
 import { useTrackers, Tracker } from '../../hooks/useTrackers'
 
-const TRACKER_COLUMNS: Column<Tracker>[] = [
-  { key: 'serialNumber', label: 'Serial Number' },
-  { key: 'licensePlate', label: 'License Plate' }
-]
+type TrackerRow = Tracker & {
+  status: string
+  lastUpdateLabel: string
+}
 
 function Trackings() {
   const navigate = useNavigate()
-  const { trackers, loading, deleteTracker } = useTrackers()
+  const { trackers, loading, deleteTracker, statusBySerial, dateBySerial } = useTrackers()
 
   const handleDelete = (tracker: Tracker) => {
     deleteTracker(tracker.id)
   }
+
+  const rows: TrackerRow[] = trackers.map(tracker => {
+    const status = statusBySerial.get(tracker.serialNumber) || 'OFF'
+    const lastDate = dateBySerial.get(tracker.serialNumber)
+    return {
+      ...tracker,
+      status,
+      lastUpdateLabel: lastDate ? new Date(lastDate).toLocaleString() : 'No data'
+    }
+  })
+
+  const TRACKER_COLUMNS: Column<TrackerRow>[] = [
+    { key: 'serialNumber', label: 'Serial Number' },
+    { key: 'licensePlate', label: 'Alias' },
+    {
+      key: 'status',
+      label: 'Estado',
+      render: (row) => (
+        <span
+          title={row.status}
+          style={{
+            display: 'inline-block',
+            width: 12,
+            height: 12,
+            borderRadius: '50%',
+            background: row.status === 'ON' ? '#22c55e' : '#ef4444',
+            border: '1px solid #d1d5db'
+          }}
+        />
+      )
+    },
+    { key: 'lastUpdateLabel', label: 'Última señal' },
+    {
+      key: 'viewMap',
+      label: 'Acción',
+      render: (row) => (
+        <button
+          className="button is-small is-warning is-outlined is-rounded"
+          onClick={() => navigate('/home', { state: { focusSerial: row.serialNumber } })}
+        >
+          Ver en el mapa
+        </button>
+      )
+    }
+  ]
 
   return (
     <PageShell
@@ -27,7 +72,7 @@ function Trackings() {
         ? <p className="has-text-centered has-text-grey">Loading…</p>
         : <DataTable
             columns={TRACKER_COLUMNS}
-            rows={trackers}
+            rows={rows}
             onDelete={handleDelete}
             emptyMessage="No trackers yet. Add your first one!"
           />

--- a/track-app/src/hooks/useTrackers.ts
+++ b/track-app/src/hooks/useTrackers.ts
@@ -1,10 +1,11 @@
 import { toast } from 'react-toastify'
-import { useGetTrackersQuery, useDeleteTrackerMutation, GetTrackersQuery } from '../generated/graphql'
+import { useGetTrackersQuery, useDeleteTrackerMutation, useLastTracksQuery, GetTrackersQuery } from '../generated/graphql'
 
 export type Tracker = NonNullable<GetTrackersQuery['trackers']>[number]
 
 export function useTrackers() {
   const { data, loading, refetch } = useGetTrackersQuery({ fetchPolicy: 'cache-and-network' })
+  const { data: lastTracksData, loading: lastTracksLoading } = useLastTracksQuery({ fetchPolicy: 'cache-and-network' })
 
   const [deleteTrackerMutation] = useDeleteTrackerMutation({
     onCompleted: () => {
@@ -15,7 +16,11 @@ export function useTrackers() {
   })
 
   const trackers: Tracker[] = data?.trackers ?? []
+  const lastTracks = lastTracksData?.lastTracks ?? []
+  const statusBySerial = new Map(lastTracks.map(track => [track.serialNumber, track.status]))
+  const dateBySerial = new Map(lastTracks.map(track => [track.serialNumber, track.date]))
+
   const deleteTracker = (id: string) => deleteTrackerMutation({ variables: { id } })
 
-  return { trackers, loading, deleteTracker, refetch }
+  return { trackers, loading: loading || lastTracksLoading, deleteTracker, refetch, statusBySerial, dateBySerial }
 }


### PR DESCRIPTION
Summary:\n- rename tracker table label from License Plate to Alias\n- add status LED column based on last track status\n- add action 'Ver en el mapa' that opens /home and focuses the selected tracker\n- update New Tracker form label to Alias\n\nValidation:\n- npm run -w track-app typecheck\n\nNotes:\n- stacked on top of feat/authz-and-users-management