### PR TITLE
fix(ui): reliable home popup actions and trackers delete confirm

### DIFF
--- a/track-app/src/components/Home/index.tsx
+++ b/track-app/src/components/Home/index.tsx
@@ -64,10 +64,22 @@ function Home({ darkmode }: HomeProps) {
           <div class="tracker-popup__title">${poi.title}</div>
           <div class="tracker-popup__meta">lat: ${poi.latitude}</div>
           <div class="tracker-popup__meta">lng: ${poi.longitude}</div>
-          <button id="deletePOI" value="${poi.id}" class="tracker-popup__button tracker-popup__button--danger">Delete</button>
+          <button data-action="delete-poi" data-id="${poi.id}" class="tracker-popup__button tracker-popup__button--danger">Delete</button>
         </div>
       `
       marker.bindPopup(popupHtml)
+      marker.on('popupopen', () => {
+        const popupNode = marker.getPopup()?.getElement()
+        if (!popupNode) return
+        const deleteBtn = popupNode.querySelector<HTMLButtonElement>('[data-action="delete-poi"]')
+        if (deleteBtn) {
+          deleteBtn.onclick = (event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            deletePOI(deleteBtn.dataset.id || '')
+          }
+        }
+      })
       marker.addTo(mapRef.current!)
       poiMarkRef.current.push(marker)
     })
@@ -122,7 +134,7 @@ function Home({ darkmode }: HomeProps) {
             <span>Telemetry</span>
             <strong style="color:${freshness.color}">${freshness.label}</strong>
           </div>
-          <button id="detailTracker" value="${sn}" class="tracker-popup__button">View Detail</button>
+          <button data-action="detail-tracker" data-serial="${sn}" class="tracker-popup__button">View Detail</button>
         </div>
       `
 
@@ -160,6 +172,17 @@ function Home({ darkmode }: HomeProps) {
         marker.on('popupopen', () => {
           followSerialRef.current = sn
           lastFollowPanAtRef.current = 0
+          const popupNode = marker.getPopup()?.getElement()
+          if (!popupNode) return
+          const detailBtn = popupNode.querySelector<HTMLButtonElement>('[data-action="detail-tracker"]')
+          if (detailBtn) {
+            detailBtn.onclick = (event) => {
+              event.preventDefault()
+              event.stopPropagation()
+              getCoords()
+              goToDetail(detailBtn.dataset.serial || '')
+            }
+          }
         })
         marker.on('popupclose', () => {
           if (followSerialRef.current === sn) followSerialRef.current = null
@@ -284,22 +307,6 @@ function Home({ darkmode }: HomeProps) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [darkmode])
-
-  // Set up click delegation for map popup buttons
-  useEffect(() => {
-    const handleMapClick = (e: MouseEvent) => {
-      const target = e.target as HTMLButtonElement
-      if (!target?.id) return
-      if (target.id === 'deletePOI') deletePOI(target.value)
-      if (target.id === 'detailTracker') {
-        getCoords()
-        goToDetail(target.value)
-      }
-    }
-    window.addEventListener('click', handleMapClick)
-    return () => window.removeEventListener('click', handleMapClick)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [trackers])
 
   // Cleanup map on unmount
   useEffect(() => {

--- a/track-app/src/components/Trackings/index.tsx
+++ b/track-app/src/components/Trackings/index.tsx
@@ -11,6 +11,8 @@ type TrackerRow = Tracker & {
 function Trackings() {
   const navigate = useNavigate()
   const [page, setPage] = useState(1)
+  const [pendingDelete, setPendingDelete] = useState<TrackerRow | null>(null)
+  const [deleting, setDeleting] = useState(false)
   const { trackers, totalCount, loading, deleteTracker, statusBySerial } = useTrackers(page, 20)
 
   const rows: TrackerRow[] = trackers.map(tracker => {
@@ -47,7 +49,8 @@ function Trackings() {
       render: (row) => (
         <div style={{ display: 'flex', gap: 8 }}>
           <button
-            className="button is-small is-warning is-outlined is-rounded"
+            className="button is-small is-warning is-rounded"
+            style={{ fontSize: 16, lineHeight: 1, minWidth: 36, color: '#1f2937' }}
             onClick={() => navigate('/home', { state: { focusSerial: row.serialNumber } })}
             title="Ver en el mapa"
             aria-label="Ver en el mapa"
@@ -55,8 +58,9 @@ function Trackings() {
             <span aria-hidden="true">👁</span>
           </button>
           <button
-            className="button is-small is-danger is-outlined is-rounded"
-            onClick={() => deleteTracker(row.id)}
+            className="button is-small is-danger is-rounded"
+            style={{ fontSize: 16, lineHeight: 1, minWidth: 36, color: '#ffffff' }}
+            onClick={() => setPendingDelete(row)}
             title="Eliminar tracker"
             aria-label="Eliminar tracker"
           >
@@ -68,27 +72,65 @@ function Trackings() {
   ]
 
   return (
-    <PageShell
-      title="Trackers"
-      actionLabel="+ New Tracker"
-      onAction={() => navigate('/trackers/new')}
-    >
-      {loading
-        ? <p className="has-text-centered has-text-grey">Loading…</p>
-        : <DataTable
-            columns={TRACKER_COLUMNS}
-            rows={rows}
-            emptyMessage="No trackers yet. Add your first one!"
-            pageSize={20}
-            serverPagination={{
-              enabled: true,
-              currentPage: page,
-              totalCount,
-              onPageChange: setPage
-            }}
-          />
-      }
-    </PageShell>
+    <>
+      <PageShell
+        title="Trackers"
+        actionLabel="+ New Tracker"
+        onAction={() => navigate('/trackers/new')}
+      >
+        {loading
+          ? <p className="has-text-centered has-text-grey">Loading…</p>
+          : <DataTable
+              columns={TRACKER_COLUMNS}
+              rows={rows}
+              emptyMessage="No trackers yet. Add your first one!"
+              pageSize={20}
+              serverPagination={{
+                enabled: true,
+                currentPage: page,
+                totalCount,
+                onPageChange: setPage
+              }}
+            />
+        }
+      </PageShell>
+
+      <div className={`modal ${pendingDelete ? 'is-active' : ''}`}>
+        <div className="modal-background" onClick={() => !deleting && setPendingDelete(null)} />
+        <div className="modal-card">
+          <header className="modal-card-head">
+            <p className="modal-card-title">Confirm Delete</p>
+            <button className="delete" aria-label="close" onClick={() => !deleting && setPendingDelete(null)} />
+          </header>
+          <section className="modal-card-body">
+            {pendingDelete && (
+              <p>
+                Delete tracker <strong>{pendingDelete.licensePlate || pendingDelete.serialNumber}</strong>?
+              </p>
+            )}
+          </section>
+          <footer className="modal-card-foot">
+            <button
+              className={`button is-danger ${deleting ? 'is-loading' : ''}`}
+              disabled={!pendingDelete || deleting}
+              onClick={async () => {
+                if (!pendingDelete) return
+                setDeleting(true)
+                try {
+                  await deleteTracker(pendingDelete.id)
+                  setPendingDelete(null)
+                } finally {
+                  setDeleting(false)
+                }
+              }}
+            >
+              Delete
+            </button>
+            <button className="button" disabled={deleting} onClick={() => setPendingDelete(null)}>Cancel</button>
+          </footer>
+        </div>
+      </div>
+    </>
   )
 }
 


### PR DESCRIPTION
Summary:\n- fix unreliable popup actions in /home by binding button handlers on popup open\n- improve popup interaction stability when clicking View Detail\n- add delete confirmation modal in /trackers table\n- improve visibility/contrast of Actions icon buttons in /trackers\n\nValidation:\n- npm run -w track-app typecheck