### PR TITLE
fix(security): isolate home live tracks by company

### DIFF
--- a/track-api/src/graphql/resolvers/tracking.resolver.js
+++ b/track-api/src/graphql/resolvers/tracking.resolver.js
@@ -96,7 +96,8 @@ const trackingResolver = {
       subscribe: async (_, __, ctx) => {
         const userId = requireAuth(ctx) // throws UNAUTHENTICATED if no userId
         await requireAccess(userId, { feature: 'tracking', permission: 'tracking.read' })
-        return pubsub.asyncIterator(['LIVE_TRACKS_UPDATED'])
+        const companyId = await service.resolveUserCompanyId(userId)
+        return pubsub.asyncIterator([`LIVE_TRACKS_UPDATED_${companyId}`])
       }
     }
   }

--- a/track-api/src/tracking/tracking.service.js
+++ b/track-api/src/tracking/tracking.service.js
@@ -5,6 +5,16 @@ const repo = require('./tracking.repository')
 const { ensureUserCompany } = require('../shared/company-context')
 
 const trackingService = {
+    async resolveUserCompanyId(userId) {
+        validate.arguments([
+            { name: 'id', value: userId, type: String, notEmpty: true }
+        ])
+
+        const user = await User.findById(userId)
+        if (!user) throw new LogicError(`user with id ${userId} doesn't exists`)
+        return ensureUserCompany(user)
+    },
+
     addTrack(userId, trackData) {
         if (!trackData) throw new InputError('incorrect track info')
         if (typeof trackData.speed === 'undefined') trackData.speed = 0
@@ -61,14 +71,20 @@ const trackingService = {
             if (!tracker) {
                 const owner = await repo.findLegacyOwnerBySerial(serialNumber)
                 if (!owner) return null
-                const legacy = owner.trackers.find(t => t.serialNumber === serialNumber)
-                tracker = { serialNumber, licensePlate: legacy?.licensePlate || null }
+                const ownerUser = await User.findById(owner._id)
+                if (!ownerUser) return null
+                const ownerCompanyId = await ensureUserCompany(ownerUser)
+                await repo.syncLegacyTrackers(ownerCompanyId, ownerUser.trackers || [])
+                tracker = await repo.findTrackerBySerial(serialNumber)
+                if (!tracker) return null
             }
 
             const track = await repo.createTrack({ serialNumber, latitude, longitude, speed, status, date })
 
             const pubsub = require('../graphql/pubsub')
-            pubsub.publish('LIVE_TRACKS_UPDATED', {
+            const companyId = tracker.companyId ? tracker.companyId.toString() : null
+            if (!companyId) return track
+            pubsub.publish(`LIVE_TRACKS_UPDATED_${companyId}`, {
                 liveTracksUpdated: [{
                     serialNumber,
                     latitude,

--- a/track-api/src/tracking/tracking.service.spec.js
+++ b/track-api/src/tracking/tracking.service.spec.js
@@ -151,7 +151,7 @@ describe('trackingService', () => {
             await trackingService.addTrackTCP(trackData)
 
             expect(publishSpy).toHaveBeenCalledWith(
-                'LIVE_TRACKS_UPDATED',
+                expect.stringMatching(/^LIVE_TRACKS_UPDATED_/),
                 expect.objectContaining({
                     liveTracksUpdated: expect.arrayContaining([
                         expect.objectContaining({ serialNumber: '1234567890' })

--- a/track-app/src/hooks/useLiveTracks.ts
+++ b/track-app/src/hooks/useLiveTracks.ts
@@ -60,14 +60,31 @@ export function useLiveTracks() {
     const incoming = liveData?.liveTracksUpdated ?? []
     if (!incoming.length) return
 
+    const ownSerials = new Set((trackersData?.trackers?.items ?? []).map(t => t.serialNumber))
+    const scopedIncoming = incoming.filter(track => ownSerials.has(track.serialNumber))
+    if (!scopedIncoming.length) return
+
     // Upsert each incoming track into the accumulated map
-    incoming.forEach(track => {
+    scopedIncoming.forEach(track => {
       positionsMapRef.current.set(track.serialNumber, track)
     })
 
     // Emit a new array snapshot to trigger map update
     setLivePositions([...positionsMapRef.current.values()])
-  }, [liveData])
+  }, [liveData, trackersData])
+
+  useEffect(() => {
+    const ownSerials = new Set((trackersData?.trackers?.items ?? []).map(t => t.serialNumber))
+    if (!ownSerials.size) {
+      positionsMapRef.current.clear()
+      setLivePositions([])
+      return
+    }
+
+    const next = [...positionsMapRef.current.values()].filter(track => ownSerials.has(track.serialNumber))
+    positionsMapRef.current = new Map(next.map(track => [track.serialNumber, track]))
+    setLivePositions(next)
+  }, [trackersData])
 
   const pois: HomePoi[] = poisData?.pois?.items ?? []
   const trackers: HomeTracker[] = trackersData?.trackers?.items ?? []


### PR DESCRIPTION
Problema:\nLa subscription de live tracks en home usaba un canal global y podia filtrar telemetria entre companies.\n\nCambios:\n- Scope de subscription por companyId en backend con canal LIVE_TRACKS_UPDATED_companyId\n- Publicacion TCP de eventos live en canal segmentado por company\n- Filtro defensivo en frontend para aceptar solo seriales de trackers de la company actual\n- Ajuste de test en tracking service para validar canal segmentado\n\nValidacion:\n- track-api: npm run test -- src/tracking/tracking.service.spec.js\n- track-app: npm run typecheck