### PR TITLE
feat(backoffice): tabs UI and auto-generated company slug

### DIFF
--- a/track-api/src/backoffice/backoffice.service.js
+++ b/track-api/src/backoffice/backoffice.service.js
@@ -10,6 +10,40 @@ function assertValidRole(role) {
     if (!VALID_ROLES.has(role)) throw new InputError(`invalid role ${role}`)
 }
 
+function slugifyCompanyName(name) {
+    const base = String(name || '')
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .replace(/-{2,}/g, '-')
+    return base || 'company'
+}
+
+function shortTimestamp() {
+    const d = new Date()
+    const pad = (value) => String(value).padStart(2, '0')
+    return `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}`
+}
+
+async function buildUniqueCompanySlug(baseSlug) {
+    const existing = await repo.findCompanyBySlug(baseSlug)
+    if (!existing) return baseSlug
+
+    const tsSlug = `${baseSlug}-${shortTimestamp()}`
+    const existingTs = await repo.findCompanyBySlug(tsSlug)
+    if (!existingTs) return tsSlug
+
+    // Defensive fallback in the unlikely case of same-second collision.
+    let attempt = 2
+    let candidate = `${tsSlug}-${attempt}`
+    while (await repo.findCompanyBySlug(candidate)) {
+        attempt += 1
+        candidate = `${tsSlug}-${attempt}`
+    }
+    return candidate
+}
+
 const backofficeService = {
     normalizePagination(offset = 0, limit = 20) {
         const _offset = Math.max(0, Number(offset || 0))
@@ -26,22 +60,21 @@ const backofficeService = {
         return repo.listCompanies()
     },
 
-    async createCompany(requesterId, { name, slug, active = true, featureKeys } = {}) {
+    async createCompany(requesterId, { name, active = true, featureKeys } = {}) {
         await requireAccess(requesterId, { feature: 'backoffice', permission: 'companies.create' })
         validate.arguments([
-            { name: 'name', value: name, type: String, notEmpty: true },
-            { name: 'slug', value: slug, type: String, notEmpty: true }
+            { name: 'name', value: name, type: String, notEmpty: true }
         ])
         if (typeof active !== 'boolean') throw new InputError('active should be a boolean')
         if (featureKeys && !Array.isArray(featureKeys)) throw new InputError('featureKeys should be an array')
 
-        const existing = await repo.findCompanyBySlug(slug)
-        if (existing) throw new LogicError(`company with slug ${slug} already exists`)
+        const baseSlug = slugifyCompanyName(name)
+        const resolvedSlug = await buildUniqueCompanySlug(baseSlug)
 
         const resolvedFeatureKeys = featureKeys && featureKeys.length > 0 ? featureKeys : FEATURE_KEYS
         return repo.createCompany({
             name,
-            slug,
+            slug: resolvedSlug,
             active,
             featuresVersion: ACCESS_VERSION,
             featuresPacked: encodeFeatureKeys(resolvedFeatureKeys)

--- a/track-api/src/graphql/schema.graphql
+++ b/track-api/src/graphql/schema.graphql
@@ -102,7 +102,7 @@ input UpdateUserInput {
 
 input BackofficeCreateCompanyInput {
   name: String!
-  slug: String!
+  slug: String
   active: Boolean
   featureKeys: [String!]
 }

--- a/track-app/src/components/Backoffice/index.tsx
+++ b/track-app/src/components/Backoffice/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import PageShell from '../shared/PageShell'
 import DataTable, { Column } from '../shared/DataTable'
 import { useBackoffice, BackofficeCompany, BackofficeUser } from '../../hooks/useBackoffice'
@@ -51,6 +51,8 @@ interface BackofficeProps {
   canUpdateUsers?: boolean
 }
 
+type BackofficeTab = 'companies' | 'users'
+
 function Backoffice({
   canReadUsers = true,
   canCreateUsers = true,
@@ -58,9 +60,10 @@ function Backoffice({
 }: BackofficeProps) {
   const [usersPage, setUsersPage] = useState(1)
   const { companies, users, usersTotalCount, loading, createCompany, createUser, updateCompany, updateUser } = useBackoffice(usersPage, 20, canReadUsers)
+  const canSeeUsersTab = canReadUsers || canCreateUsers || canUpdateUsers
+  const [activeTab, setActiveTab] = useState<BackofficeTab>('companies')
   const [companyForm, setCompanyForm] = useState({
     name: '',
-    slug: '',
     active: true,
     featureKeys: [...FEATURE_KEYS]
   })
@@ -83,14 +86,17 @@ function Backoffice({
 
   const onCreateCompany = async (e: React.FormEvent) => {
     e.preventDefault()
-    await createCompany(companyForm.name, companyForm.slug, companyForm.active, companyForm.featureKeys)
+    await createCompany(companyForm.name, companyForm.active, companyForm.featureKeys)
     setCompanyForm({
       name: '',
-      slug: '',
       active: true,
       featureKeys: [...FEATURE_KEYS]
     })
   }
+
+  useEffect(() => {
+    if (!canSeeUsersTab && activeTab === 'users') setActiveTab('companies')
+  }, [activeTab, canSeeUsersTab])
 
   const onCreateUser = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -189,6 +195,21 @@ function Backoffice({
     <PageShell title="Backoffice">
       {loading && <p className="has-text-centered has-text-grey">Loading...</p>}
 
+      <div className="tabs is-toggle is-toggle-rounded" style={{ marginBottom: 24 }}>
+        <ul>
+          <li className={activeTab === 'companies' ? 'is-active' : ''}>
+            <a onClick={() => setActiveTab('companies')}>Companies</a>
+          </li>
+          {canSeeUsersTab && (
+            <li className={activeTab === 'users' ? 'is-active' : ''}>
+              <a onClick={() => setActiveTab('users')}>Users</a>
+            </li>
+          )}
+        </ul>
+      </div>
+
+      {activeTab === 'companies' && (
+      <>
       <section style={{ marginBottom: 24 }}>
         <h3 className="title is-5">Create Company</h3>
         <form onSubmit={onCreateCompany}>
@@ -196,12 +217,6 @@ function Backoffice({
             <label className="label">Name</label>
             <div className="control">
               <input className="input" value={companyForm.name} onChange={(e) => setCompanyForm(prev => ({ ...prev, name: e.target.value }))} required />
-            </div>
-          </div>
-          <div className="field">
-            <label className="label">Slug</label>
-            <div className="control">
-              <input className="input" value={companyForm.slug} onChange={(e) => setCompanyForm(prev => ({ ...prev, slug: e.target.value }))} required />
             </div>
           </div>
           <div className="field">
@@ -235,8 +250,10 @@ function Backoffice({
         <h3 className="title is-5">Companies</h3>
         <DataTable columns={COMPANY_COLUMNS} rows={companies} emptyMessage="No companies yet." />
       </section>
+      </>
+      )}
 
-      {canCreateUsers && (
+      {activeTab === 'users' && canCreateUsers && (
       <section style={{ marginBottom: 24 }}>
         <h3 className="title is-5">Create User</h3>
         <form onSubmit={onCreateUser}>
@@ -329,7 +346,7 @@ function Backoffice({
             </div>
             <div className="field">
               <label className="label">Slug</label>
-              <input className="input" value={companyEdit.slug} onChange={(e) => setCompanyEdit(prev => ({ ...prev, slug: e.target.value }))} required />
+              <input className="input" value={companyEdit.slug} readOnly />
             </div>
             <div className="field">
               <label className="checkbox">
@@ -359,7 +376,7 @@ function Backoffice({
         )}
       </section>
 
-      {canReadUsers && canUpdateUsers && (
+      {activeTab === 'users' && canReadUsers && canUpdateUsers && (
       <section style={{ marginBottom: 24 }}>
         <h3 className="title is-5">Edit User</h3>
         <div className="field">
@@ -440,7 +457,7 @@ function Backoffice({
       </section>
       )}
 
-      {canReadUsers && (
+      {activeTab === 'users' && canReadUsers && (
       <section>
         <h3 className="title is-5">Users</h3>
         <DataTable

--- a/track-app/src/components/Backoffice/index.tsx
+++ b/track-app/src/components/Backoffice/index.tsx
@@ -325,6 +325,7 @@ function Backoffice({
       </section>
       )}
 
+      {activeTab === 'companies' && (
       <section style={{ marginBottom: 24 }}>
         <h3 className="title is-5">Edit Company</h3>
         <div className="field">
@@ -375,6 +376,7 @@ function Backoffice({
           </form>
         )}
       </section>
+      )}
 
       {activeTab === 'users' && canReadUsers && canUpdateUsers && (
       <section style={{ marginBottom: 24 }}>

--- a/track-app/src/generated/graphql.ts
+++ b/track-app/src/generated/graphql.ts
@@ -44,7 +44,7 @@ export type BackofficeCreateCompanyInput = {
   active?: InputMaybe<Scalars['Boolean']['input']>;
   featureKeys?: InputMaybe<Array<Scalars['String']['input']>>;
   name: Scalars['String']['input'];
-  slug: Scalars['String']['input'];
+  slug?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type BackofficeCreateUserInput = {

--- a/track-app/src/hooks/useBackoffice.ts
+++ b/track-app/src/hooks/useBackoffice.ts
@@ -88,8 +88,8 @@ export function useBackoffice(usersPage = 1, pageSize = 20, enableUsersQuery = t
         [usersQuery.data]
     )
 
-    const createCompany = async (name: string, slug: string, active: boolean, featureKeys?: string[]) => {
-        const res = await createCompanyMutation({ variables: { input: { name, slug, active, featureKeys } } })
+    const createCompany = async (name: string, active: boolean, featureKeys?: string[]) => {
+        const res = await createCompanyMutation({ variables: { input: { name, active, featureKeys } } })
         if (res.data?.backofficeCreateCompany.success) toast.success(res.data.backofficeCreateCompany.message)
     }
 


### PR DESCRIPTION
Summary:\n- split backoffice into two tabs: Companies and Users\n- remove slug input from company creation form\n- keep company slug read-only in edit form\n- make BackofficeCreateCompanyInput.slug optional\n- auto-generate unique company slug in backend with timestamp fallback\n\nValidation:\n- track-app: npm run typecheck\n- track-api: npm run test -- src/shared/access-control.spec.js\n- codegen: executed successfully against local GraphQL endpoint