### PR TITLE
feat: alias-only trackers + mongo tracks storage optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,13 @@ npm run migrate:api
 # Run one specific migration by timestamp or timestamp+name
 npm run migrate:api -- 20260411143000
 npm run migrate:api -- 20260411143000-add-company-index
-npm run migrate:api -- 2026-04-10-backfill-user-language  # compatibilidad legacy
+npm run migrate:api -- 20260410000000-backfill-user-language
 ```
 
 For this to work in production, make sure `MONGO_URL` points to your production database.
 
 Current migration included:
-- `2026-04-10-backfill-user-language`: sets `language = "en"` for users where language is missing/null/empty.
+- `20260410000000-backfill-user-language`: sets `language = "en"` for users where language is missing/null/empty.
 
 Create a new migration template (timestamp auto-generated):
 
@@ -118,6 +118,14 @@ Optional: pass full name manually:
 
 ```bash
 npm run migrate:api:new -- 20260411143000-add-company-index
+```
+
+### Mongo storage diagnostics
+
+Inspect collection and index size footprint:
+
+```bash
+npm run db:report -w track-api
 ```
 
 ### Simulated trucks

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,6 +3,11 @@ services:
     image: mongo:7
     container_name: tortoise-mongo
     restart: unless-stopped
+    command:
+      - "mongod"
+      - "--wiredTigerCollectionBlockCompressor=zstd"
+      - "--wiredTigerJournalCompressor=zstd"
+      - "--wiredTigerIndexPrefixCompression=1"
     volumes:
       - mongo-data:/data/db
     # No port exposed publicly — only accessible internally

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,11 @@ services:
     image: mongo:7
     container_name: tortoise-mongo
     restart: unless-stopped
+    command:
+      - "mongod"
+      - "--wiredTigerCollectionBlockCompressor=zstd"
+      - "--wiredTigerJournalCompressor=zstd"
+      - "--wiredTigerIndexPrefixCompression=1"
     ports:
       - "27017:27017"
     volumes:

--- a/start_local.sh
+++ b/start_local.sh
@@ -11,7 +11,12 @@ sleep 2
 
 echo "🍃 Iniciando MongoDB local en /tmp/tortoise_mongo..."
 mkdir -p /tmp/tortoise_mongo
-mongod --dbpath /tmp/tortoise_mongo --port 27017 > /tmp/mongo.log 2>&1 &
+mongod \
+  --dbpath /tmp/tortoise_mongo \
+  --port 27017 \
+  --wiredTigerCollectionBlockCompressor=zstd \
+  --wiredTigerJournalCompressor=zstd \
+  --wiredTigerIndexPrefixCompression=1 > /tmp/mongo.log 2>&1 &
 sleep 3
 
 echo "🔌 Iniciando Backend API (Puerto 8085)..."

--- a/track-api/package.json
+++ b/track-api/package.json
@@ -11,6 +11,7 @@
     "test:watch": "vitest",
     "promote:staff": "node scripts/promote-staff.js",
     "seed:e2e": "node scripts/seed-e2e.js",
+    "db:report": "node scripts/db-storage-report.js",
     "migrate": "node scripts/migrate.js",
     "migrate:dry": "node scripts/migrate.js --dry-run",
     "migrate:new": "node scripts/migrate-new.js"

--- a/track-api/scripts/db-storage-report.js
+++ b/track-api/scripts/db-storage-report.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+require('dotenv').config()
+
+const { mongoose } = require('track-data')
+
+function bytesToMB(bytes) {
+    return Math.round((Number(bytes || 0) / (1024 * 1024)) * 100) / 100
+}
+
+async function getCollectionStats(db, name) {
+    try {
+        return await db.command({ collStats: name })
+    } catch (_) {
+        return null
+    }
+}
+
+async function main() {
+    const mongoUrl = process.env.MONGO_URL
+    if (!mongoUrl) throw new Error('MONGO_URL is required')
+
+    await mongoose.connect(mongoUrl)
+    const db = mongoose.connection.db
+    const collections = await db.listCollections({}, { nameOnly: true }).toArray()
+
+    const rows = []
+    for (const { name } of collections) {
+        const stats = await getCollectionStats(db, name)
+        if (!stats) continue
+
+        const totalIndexSize = Number(stats.totalIndexSize || 0)
+        const storageSize = Number(stats.storageSize || 0)
+        const dataSize = Number(stats.size || 0)
+
+        rows.push({
+            collection: name,
+            count: Number(stats.count || 0),
+            dataMB: bytesToMB(dataSize),
+            storageMB: bytesToMB(storageSize),
+            indexes: Number(stats.nindexes || 0),
+            indexMB: bytesToMB(totalIndexSize),
+            indexSizes: stats.indexSizes || {}
+        })
+    }
+
+    rows.sort((a, b) => (b.dataMB + b.indexMB) - (a.dataMB + a.indexMB))
+
+    console.log('=== MongoDB Storage Report ===')
+    console.table(rows.map(row => ({
+        collection: row.collection,
+        count: row.count,
+        dataMB: row.dataMB,
+        storageMB: row.storageMB,
+        indexes: row.indexes,
+        indexMB: row.indexMB
+    })))
+
+    const top = rows[0]
+    if (top) {
+        const indexEntries = Object.entries(top.indexSizes)
+            .map(([name, size]) => ({ name, mb: bytesToMB(size) }))
+            .sort((a, b) => b.mb - a.mb)
+        console.log(`Top collection by size: ${top.collection}`)
+        console.table(indexEntries)
+    }
+}
+
+main()
+    .catch((err) => {
+        console.error(err.message)
+        process.exitCode = 1
+    })
+    .finally(async () => {
+        try {
+            await mongoose.disconnect()
+        } catch (_) {
+            // ignore disconnect errors
+        }
+    })
+

--- a/track-api/scripts/migrate.js
+++ b/track-api/scripts/migrate.js
@@ -24,11 +24,15 @@ function printHelp() {
     console.log('  node scripts/migrate.js --dry-run')
     console.log('  node scripts/migrate.js 20260411143000')
     console.log('  node scripts/migrate.js 20260411143000-add-company-index')
-    console.log('  node scripts/migrate.js 2026-04-10-backfill-user-language')
+    console.log('  node scripts/migrate.js 20260410000000-backfill-user-language')
 }
 
 function normalizeDatePrefix(value) {
     return value.replace(/^(\d{4})-(\d{2})-(\d{2})/, '$1$2$3')
+}
+
+function isValidMigrationFileName(fileName) {
+    return /^\d{14}-[a-z0-9]+(?:-[a-z0-9]+)*\.js$/.test(fileName)
 }
 
 async function loadMigrations(dir, onlyRef) {
@@ -37,13 +41,23 @@ async function loadMigrations(dir, onlyRef) {
         .filter((f) => f.endsWith('.js'))
         .sort()
 
+    const invalidFiles = files.filter((file) => !isValidMigrationFileName(file))
+    if (invalidFiles.length) {
+        throw new Error(
+            `invalid migration filename(s): ${invalidFiles.join(', ')}. Expected pattern YYYYMMDDHHmmss-name.js`
+        )
+    }
+
     const loaded = files.map((file) => {
         const migration = require(path.join(dir, file))
         const name = migration.name || file.replace(/\.js$/, '')
+        const aliases = Array.isArray(migration.aliases)
+            ? [...new Set(migration.aliases.filter((value) => typeof value === 'string' && value.trim()))]
+            : []
         if (typeof migration.up !== 'function') {
             throw new Error(`invalid migration ${file}: missing up()`)
         }
-        return { file, name, up: migration.up }
+        return { file, name, aliases, up: migration.up }
     })
 
     if (!onlyRef) return loaded
@@ -52,18 +66,20 @@ async function loadMigrations(dir, onlyRef) {
     const onlyNormalized = normalizeDatePrefix(only)
     const filtered = loaded.filter((m) => {
         const base = m.file.replace(/\.js$/, '')
+        const refs = [m.name, base, ...m.aliases]
         const nameNormalized = normalizeDatePrefix(m.name)
         const baseNormalized = normalizeDatePrefix(base)
+        const aliasNormalized = m.aliases.map(normalizeDatePrefix)
         return (
-            m.name === only ||
+            refs.includes(only) ||
             m.file === onlyRef ||
-            base === only ||
-            m.name.startsWith(only) ||
-            base.startsWith(only) ||
+            refs.some((ref) => ref.startsWith(only)) ||
             nameNormalized === onlyNormalized ||
             baseNormalized === onlyNormalized ||
+            aliasNormalized.includes(onlyNormalized) ||
             nameNormalized.startsWith(onlyNormalized) ||
-            baseNormalized.startsWith(onlyNormalized)
+            baseNormalized.startsWith(onlyNormalized) ||
+            aliasNormalized.some((ref) => ref.startsWith(onlyNormalized))
         )
     })
 
@@ -99,7 +115,10 @@ async function main() {
 
     const executed = await journal.find({}, { projection: { _id: 0, name: 1 } }).toArray()
     const executedSet = new Set(executed.map((d) => d.name))
-    const pending = migrations.filter((m) => !executedSet.has(m.name))
+    const pending = migrations.filter((m) => {
+        const allNames = [m.name, ...m.aliases]
+        return !allNames.some((migrationName) => executedSet.has(migrationName))
+    })
 
     if (pending.length === 0) {
         console.log(dryRun ? 'No pending migrations (dry-run).' : 'No pending migrations.')
@@ -120,6 +139,7 @@ async function main() {
             await journal.insertOne({
                 name: migration.name,
                 file: migration.file,
+                aliases: migration.aliases,
                 executedAt: new Date(),
                 details: details || null
             })

--- a/track-api/scripts/migrations/20260410000000-backfill-user-language.js
+++ b/track-api/scripts/migrations/20260410000000-backfill-user-language.js
@@ -1,7 +1,9 @@
-const NAME = '2026-04-10-backfill-user-language'
+const NAME = '20260410000000-backfill-user-language'
+const LEGACY_NAMES = ['2026-04-10-backfill-user-language']
 
 module.exports = {
     name: NAME,
+    aliases: LEGACY_NAMES,
     /**
      * @param {{ models: { User: import('mongoose').Model<any> }, logger: Console, dryRun: boolean }} ctx
      */
@@ -30,4 +32,3 @@ module.exports = {
         return { matched: result.matchedCount, modified: result.modifiedCount }
     }
 }
-

--- a/track-api/scripts/migrations/20260416000000-rename-licenseplate-to-alias.js
+++ b/track-api/scripts/migrations/20260416000000-rename-licenseplate-to-alias.js
@@ -1,0 +1,84 @@
+const NAME = '20260416000000-rename-licenseplate-to-alias'
+const LEGACY_NAMES = ['2026-04-16-rename-licenseplate-to-alias']
+
+module.exports = {
+    name: NAME,
+    aliases: LEGACY_NAMES,
+    /**
+     * @param {{ models: { Tracker: import('mongoose').Model<any>, User: import('mongoose').Model<any> }, logger: Console, dryRun: boolean }} ctx
+     */
+    async up({ models: { Tracker, User }, logger, dryRun }) {
+        const trackerFilter = { licensePlate: { $exists: true } }
+        const trackerDocs = await Tracker.countDocuments(trackerFilter)
+
+        const userFilter = { 'trackers.licensePlate': { $exists: true } }
+        const userDocs = await User.countDocuments(userFilter)
+
+        if (trackerDocs === 0 && userDocs === 0) {
+            logger.log(`[${NAME}] no documents require migration`)
+            return { trackerDocs: 0, trackerModified: 0, userDocs: 0, userModified: 0 }
+        }
+
+        if (dryRun) {
+            logger.log(
+                `[${NAME}] dry-run: trackers=${trackerDocs} users=${userDocs} would be migrated (licensePlate -> alias)`
+            )
+            return { trackerDocs, trackerModified: 0, userDocs, userModified: 0, dryRun: true }
+        }
+
+        let trackerModified = 0
+        if (trackerDocs > 0) {
+            const trackerResult = await Tracker.updateMany(
+                trackerFilter,
+                [
+                    {
+                        $set: {
+                            alias: {
+                                $cond: [
+                                    {
+                                        $or: [
+                                            { $eq: ['$alias', null] },
+                                            { $eq: ['$alias', ''] }
+                                        ]
+                                    },
+                                    '$licensePlate',
+                                    '$alias'
+                                ]
+                            }
+                        }
+                    },
+                    { $unset: 'licensePlate' }
+                ]
+            )
+            trackerModified = trackerResult.modifiedCount || 0
+        }
+
+        let userModified = 0
+        if (userDocs > 0) {
+            const cursor = User.find(userFilter, { trackers: 1 }).lean().cursor()
+            for await (const user of cursor) {
+                let changed = false
+                const nextTrackers = (user.trackers || []).map((tracker) => {
+                    if (!tracker || typeof tracker !== 'object') return tracker
+                    if (!Object.prototype.hasOwnProperty.call(tracker, 'licensePlate')) return tracker
+
+                    const next = { ...tracker }
+                    if (!next.alias || !String(next.alias).trim()) next.alias = next.licensePlate
+                    delete next.licensePlate
+                    changed = true
+                    return next
+                })
+
+                if (!changed) continue
+                await User.updateOne({ _id: user._id }, { $set: { trackers: nextTrackers } })
+                userModified += 1
+            }
+        }
+
+        logger.log(
+            `[${NAME}] trackerDocs=${trackerDocs} trackerModified=${trackerModified} userDocs=${userDocs} userModified=${userModified}`
+        )
+
+        return { trackerDocs, trackerModified, userDocs, userModified }
+    }
+}

--- a/track-api/scripts/migrations/20260416123000-migrate-tracks-to-timeseries.js
+++ b/track-api/scripts/migrations/20260416123000-migrate-tracks-to-timeseries.js
@@ -1,0 +1,139 @@
+const NAME = '20260416123000-migrate-tracks-to-timeseries'
+
+const BATCH_SIZE = 5000
+
+function isEnabled(value) {
+    return String(value || '').toLowerCase() === 'true'
+}
+
+module.exports = {
+    name: NAME,
+    /**
+     * @param {{ db: import('mongodb').Db, logger: Console, dryRun: boolean }} ctx
+     */
+    async up({ db, logger, dryRun }) {
+        const collections = await db.listCollections({ name: 'tracks' }).toArray()
+        if (!collections.length) {
+            logger.log(`[${NAME}] collection "tracks" does not exist; nothing to migrate`)
+            return { skipped: true, reason: 'missing_tracks_collection' }
+        }
+
+        const tracksInfo = collections[0]
+        const alreadyTimeSeries = Boolean(tracksInfo.options && tracksInfo.options.timeseries)
+        if (alreadyTimeSeries) {
+            logger.log(`[${NAME}] "tracks" is already a time series collection`)
+            return { skipped: true, reason: 'already_timeseries' }
+        }
+
+        const source = db.collection('tracks')
+        const sourceCount = await source.countDocuments({})
+        const suffix = `${Date.now()}_${Math.floor(Math.random() * 10000)}`
+        const backupName = `tracks_backup_${suffix}`
+        const keepBackup = isEnabled(process.env.MIGRATION_KEEP_TRACKS_BACKUP)
+
+        if (dryRun) {
+            logger.log(
+                `[${NAME}] dry-run: would migrate ${sourceCount} docs from regular collection "tracks" to time series`
+            )
+            return {
+                dryRun: true,
+                sourceCount,
+                backupName,
+                keepBackup
+            }
+        }
+
+        let inserted = 0
+        let backupCreated = false
+        let targetCreated = false
+        try {
+            logger.log(`[${NAME}] renaming "tracks" -> "${backupName}"`)
+            await source.rename(backupName)
+            backupCreated = true
+
+            logger.log(`[${NAME}] creating time series collection "tracks"`)
+            await db.createCollection('tracks', {
+                timeseries: {
+                    timeField: 'date',
+                    metaField: 'serialNumber',
+                    granularity: 'seconds'
+                }
+            })
+            targetCreated = true
+
+            const backup = db.collection(backupName)
+            const target = db.collection('tracks')
+            const cursor = backup.find(
+                {},
+                {
+                    projection: {
+                        _id: 0,
+                        serialNumber: 1,
+                        latitude: 1,
+                        longitude: 1,
+                        speed: 1,
+                        status: 1,
+                        date: 1
+                    }
+                }
+            )
+
+            let batch = []
+            for await (const doc of cursor) {
+                if (!(doc.date instanceof Date)) {
+                    const parsed = new Date(doc.date)
+                    doc.date = Number.isFinite(parsed.getTime()) ? parsed : new Date()
+                }
+                if (!doc.status) doc.status = 'ON'
+                batch.push(doc)
+
+                if (batch.length >= BATCH_SIZE) {
+                    await target.insertMany(batch, { ordered: false })
+                    inserted += batch.length
+                    batch = []
+                }
+            }
+
+            if (batch.length) {
+                await target.insertMany(batch, { ordered: false })
+                inserted += batch.length
+            }
+
+            logger.log(`[${NAME}] copied ${inserted} documents to "tracks"`)
+
+            // Ensure explicit ascending index for query plans shared by regular/time-series collections.
+            await target.createIndex({ serialNumber: 1, date: 1 }, { name: 'serialNumber_1_date_1' })
+
+            let droppedBackup = false
+            if (!keepBackup) {
+                await backup.drop()
+                droppedBackup = true
+                logger.log(`[${NAME}] dropped backup collection "${backupName}"`)
+            } else {
+                logger.log(`[${NAME}] backup preserved as "${backupName}" (MIGRATION_KEEP_TRACKS_BACKUP=true)`)
+            }
+
+            return {
+                migrated: true,
+                sourceCount,
+                inserted,
+                backupName,
+                droppedBackup
+            }
+        } catch (error) {
+            try {
+                if (targetCreated) {
+                    const targetExists = await db.listCollections({ name: 'tracks' }).hasNext()
+                    if (targetExists) await db.collection('tracks').drop()
+                }
+                if (backupCreated) {
+                    const backupExists = await db.listCollections({ name: backupName }).hasNext()
+                    if (backupExists) await db.collection(backupName).rename('tracks')
+                }
+            } catch (_) {
+                // ignore cleanup errors
+            }
+            throw error
+        }
+    }
+}

--- a/track-api/scripts/migrations/20260416130000-drop-redundant-tracks-desc-index.js
+++ b/track-api/scripts/migrations/20260416130000-drop-redundant-tracks-desc-index.js
@@ -1,0 +1,49 @@
+const NAME = '20260416130000-drop-redundant-tracks-desc-index'
+
+const REDUNDANT_INDEX = 'serialNumber_1_date_-1'
+const REQUIRED_INDEX = 'serialNumber_1_date_1'
+
+module.exports = {
+    name: NAME,
+    /**
+     * @param {{ db: import('mongodb').Db, logger: Console, dryRun: boolean }} ctx
+     */
+    async up({ db, logger, dryRun }) {
+        const exists = await db.listCollections({ name: 'tracks' }).hasNext()
+        if (!exists) {
+            logger.log(`[${NAME}] collection "tracks" not found; nothing to do`)
+            return { skipped: true, reason: 'missing_tracks_collection' }
+        }
+
+        const tracks = db.collection('tracks')
+        const indexes = await tracks.indexes()
+        const names = indexes.map((index) => index.name)
+        const hasRequired = names.includes(REQUIRED_INDEX)
+        const hasRedundant = names.includes(REDUNDANT_INDEX)
+
+        if (!hasRedundant) {
+            logger.log(`[${NAME}] redundant index "${REDUNDANT_INDEX}" not found`)
+            return { skipped: true, reason: 'redundant_index_missing', indexes: names }
+        }
+
+        if (!hasRequired) {
+            if (dryRun) {
+                logger.log(
+                    `[${NAME}] dry-run: required index "${REQUIRED_INDEX}" missing; would create it before dropping "${REDUNDANT_INDEX}"`
+                )
+                return { dryRun: true, wouldCreate: REQUIRED_INDEX, wouldDrop: REDUNDANT_INDEX }
+            }
+            await tracks.createIndex({ serialNumber: 1, date: 1 }, { name: REQUIRED_INDEX })
+            logger.log(`[${NAME}] created required index "${REQUIRED_INDEX}"`)
+        }
+
+        if (dryRun) {
+            logger.log(`[${NAME}] dry-run: would drop "${REDUNDANT_INDEX}" from tracks`)
+            return { dryRun: true, drop: REDUNDANT_INDEX, keep: REQUIRED_INDEX }
+        }
+
+        await tracks.dropIndex(REDUNDANT_INDEX)
+        logger.log(`[${NAME}] dropped index "${REDUNDANT_INDEX}"`)
+        return { dropped: REDUNDANT_INDEX, kept: REQUIRED_INDEX }
+    }
+}

--- a/track-api/scripts/migrations/20260416133000-pack-tracks-telemetry-fields.js
+++ b/track-api/scripts/migrations/20260416133000-pack-tracks-telemetry-fields.js
@@ -1,0 +1,113 @@
+const NAME = '20260416133000-pack-tracks-telemetry-fields'
+const BATCH_SIZE = 5000
+
+function isEnabled(value) {
+    return String(value || '').toLowerCase() === 'true'
+}
+
+function roundTo(value, decimals) {
+    const factor = 10 ** decimals
+    return Math.round(value * factor) / factor
+}
+
+function normalizeStatus(value) {
+    if (value === 1 || value === '1' || value === true) return 1
+    if (value === 0 || value === '0' || value === false) return 0
+    const normalized = String(value || '').trim().toUpperCase()
+    if (normalized === 'OFF') return 0
+    return 1
+}
+
+module.exports = {
+    name: NAME,
+    /**
+     * @param {{ db: import('mongodb').Db, logger: Console, dryRun: boolean }} ctx
+     */
+    async up({ db, logger, dryRun }) {
+        const exists = await db.listCollections({ name: 'tracks' }).hasNext()
+        if (!exists) {
+            logger.log(`[${NAME}] collection "tracks" not found; nothing to do`)
+            return { skipped: true, reason: 'missing_tracks_collection' }
+        }
+
+        const tracks = db.collection('tracks')
+        const count = await tracks.countDocuments({})
+        if (count === 0) {
+            logger.log(`[${NAME}] no tracks found`)
+            return { skipped: true, reason: 'empty_collection' }
+        }
+
+        const suffix = `${Date.now()}_${Math.floor(Math.random() * 10000)}`
+        const backupName = `tracks_repack_src_${suffix}`
+        const keepBackup = isEnabled(process.env.MIGRATION_KEEP_TRACKS_BACKUP)
+
+        if (dryRun) {
+            logger.log(`[${NAME}] dry-run: would compact ${count} tracks (status->0/1, round lat/lon/speed)`)
+            return { dryRun: true, count, backupName, keepBackup }
+        }
+
+        logger.log(`[${NAME}] snapshotting tracks into "${backupName}"`)
+        await tracks.aggregate([{ $match: {} }, { $out: backupName }], { allowDiskUse: true }).toArray()
+
+        logger.log(`[${NAME}] recreating tracks time-series collection`)
+        await tracks.drop()
+        await db.createCollection('tracks', {
+            timeseries: {
+                timeField: 'date',
+                metaField: 'serialNumber',
+                granularity: 'seconds'
+            }
+        })
+
+        const target = db.collection('tracks')
+        const backup = db.collection(backupName)
+        const cursor = backup.find(
+            {},
+            {
+                projection: {
+                    _id: 0,
+                    serialNumber: 1,
+                    latitude: 1,
+                    longitude: 1,
+                    speed: 1,
+                    status: 1,
+                    date: 1
+                }
+            }
+        )
+
+        let inserted = 0
+        let batch = []
+        for await (const doc of cursor) {
+            const latitude = roundTo(Number(doc.latitude || 0), 5)
+            const longitude = roundTo(Number(doc.longitude || 0), 5)
+            const speed = roundTo(Number(doc.speed || 0), 1)
+            const status = normalizeStatus(doc.status)
+            const date = doc.date instanceof Date ? doc.date : new Date(doc.date)
+
+            batch.push({ serialNumber: doc.serialNumber, latitude, longitude, speed, status, date })
+
+            if (batch.length >= BATCH_SIZE) {
+                await target.insertMany(batch, { ordered: false })
+                inserted += batch.length
+                batch = []
+            }
+        }
+        if (batch.length) {
+            await target.insertMany(batch, { ordered: false })
+            inserted += batch.length
+        }
+
+        await target.createIndex({ serialNumber: 1, date: 1 }, { name: 'serialNumber_1_date_1' })
+
+        if (!keepBackup) {
+            await backup.drop()
+            logger.log(`[${NAME}] dropped backup "${backupName}"`)
+        } else {
+            logger.log(`[${NAME}] backup preserved as "${backupName}"`)
+        }
+
+        logger.log(`[${NAME}] repacked ${inserted} / ${count} tracks`)
+        return { inserted, count, backupName, keptBackup: keepBackup }
+    }
+}

--- a/track-api/scripts/migrations/20260416134000-fix-trackers-alias-indexes.js
+++ b/track-api/scripts/migrations/20260416134000-fix-trackers-alias-indexes.js
@@ -1,0 +1,46 @@
+const NAME = '20260416134000-fix-trackers-alias-indexes'
+
+module.exports = {
+    name: NAME,
+    /**
+     * @param {{ db: import('mongodb').Db, logger: Console, dryRun: boolean }} ctx
+     */
+    async up({ db, logger, dryRun }) {
+        const exists = await db.listCollections({ name: 'trackers' }).hasNext()
+        if (!exists) {
+            logger.log(`[${NAME}] collection "trackers" not found; nothing to do`)
+            return { skipped: true, reason: 'missing_trackers_collection' }
+        }
+
+        const trackers = db.collection('trackers')
+        const indexes = await trackers.indexes()
+
+        const licenseIndexes = indexes
+            .filter(index => Object.prototype.hasOwnProperty.call(index.key || {}, 'licensePlate'))
+            .map(index => index.name)
+
+        const hasAlias = indexes.some(index => index.name === 'alias_1')
+
+        if (dryRun) {
+            logger.log(
+                `[${NAME}] dry-run: would drop licensePlate indexes [${licenseIndexes.join(', ')}] and ensure alias_1=${!hasAlias}`
+            )
+            return { dryRun: true, drop: licenseIndexes, createAlias: !hasAlias }
+        }
+
+        if (!hasAlias) {
+            await trackers.createIndex({ alias: 1 }, { name: 'alias_1' })
+            logger.log(`[${NAME}] created index alias_1`)
+        }
+
+        let dropped = 0
+        for (const indexName of licenseIndexes) {
+            await trackers.dropIndex(indexName)
+            dropped += 1
+            logger.log(`[${NAME}] dropped legacy index ${indexName}`)
+        }
+
+        return { createdAlias: !hasAlias, dropped }
+    }
+}
+

--- a/track-api/scripts/seed-e2e.js
+++ b/track-api/scripts/seed-e2e.js
@@ -77,7 +77,7 @@ async function main() {
             $set: {
                 companyId: company._id,
                 serialNumber: trackerSerial,
-                licensePlate: trackerAlias
+                alias: trackerAlias
             }
         },
         { upsert: true }
@@ -103,7 +103,7 @@ async function main() {
         latitude: 41.3874,
         longitude: 2.1686,
         speed: 38,
-        status: 'ON',
+        status: 1,
         date: new Date()
     })
 

--- a/track-api/src/backoffice/backoffice.repository.js
+++ b/track-api/src/backoffice/backoffice.repository.js
@@ -1,4 +1,4 @@
-const { models: { Company, User }, mongoose } = require('track-data')
+const { models: { Company, User, Tracker }, mongoose } = require('track-data')
 
 module.exports = {
     async findUserById(id) {
@@ -50,5 +50,17 @@ module.exports = {
     async updateUserById(id, patch) {
         if (!mongoose.Types.ObjectId.isValid(id)) return null
         return User.findByIdAndUpdate(id, { $set: patch }, { new: true })
+    },
+
+    async findTrackerBySerial(serialNumber) {
+        return Tracker.findOne({ serialNumber })
+    },
+
+    async findTrackerByAlias(alias) {
+        return Tracker.findOne({ alias })
+    },
+
+    async createTracker(data) {
+        return Tracker.create(data)
     }
 }

--- a/track-api/src/backoffice/backoffice.service.js
+++ b/track-api/src/backoffice/backoffice.service.js
@@ -27,6 +27,10 @@ function shortTimestamp() {
     return `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}`
 }
 
+function generateFallbackAlias() {
+    return '#IS-' + (Math.floor(Math.random() * (9999 - 1000)) + 1000).toString() + '-FAKE'
+}
+
 async function buildUniqueCompanySlug(baseSlug) {
     const existing = await repo.findCompanyBySlug(baseSlug)
     if (!existing) return baseSlug
@@ -168,6 +172,39 @@ const backofficeService = {
             companyId,
             permissionsVersion: ACCESS_VERSION,
             permissionsPacked: encodePermissionKeys(resolvedPermissionKeys)
+        })
+    },
+
+    async createTracker(requesterId, { serialNumber, alias, companyId } = {}) {
+        await requireAccess(requesterId, { feature: 'backoffice', permission: 'companies.update' })
+        validate.arguments([
+            { name: 'serialNumber', value: serialNumber, type: String, notEmpty: true },
+            { name: 'companyId', value: companyId, type: String, notEmpty: true }
+        ])
+
+        let resolvedAlias = alias
+        if (!resolvedAlias || (typeof resolvedAlias === 'string' && !resolvedAlias.trim())) {
+            resolvedAlias = generateFallbackAlias()
+        }
+        validate.arguments([
+            { name: 'alias', value: resolvedAlias, type: String, notEmpty: true }
+        ])
+
+        const company = await repo.findCompanyById(companyId)
+        if (!company) throw new LogicError(`company with id ${companyId} doesn't exists`)
+
+        const serial = await repo.findTrackerBySerial(serialNumber)
+        if (serial) throw new LogicError(`Serial Number ${serialNumber} already registered`)
+
+        if (resolvedAlias[0] !== '#') {
+            const aliasTracker = await repo.findTrackerByAlias(resolvedAlias)
+            if (aliasTracker) throw new LogicError(`Alias ${resolvedAlias} already registered`)
+        }
+
+        return repo.createTracker({
+            companyId,
+            serialNumber,
+            alias: resolvedAlias
         })
     },
 

--- a/track-api/src/fleet/fleet.repository.js
+++ b/track-api/src/fleet/fleet.repository.js
@@ -10,8 +10,8 @@ module.exports = {
         return Tracker.findOne({ serialNumber })
     },
 
-    async findTrackerByLicensePlate(licensePlate) {
-        return Tracker.findOne({ licensePlate })
+    async findTrackerByAlias(alias) {
+        return Tracker.findOne({ alias })
     },
 
     async findTrackersByCompany(companyId, { offset = 0, limit } = {}) {
@@ -33,8 +33,8 @@ module.exports = {
         return Tracker.findOne({ serialNumber, companyId }).lean()
     },
 
-    async findTrackerByLPAndCompany(licensePlate, companyId) {
-        return Tracker.findOne({ licensePlate, companyId }).lean()
+    async findTrackerByAliasAndCompany(alias, companyId) {
+        return Tracker.findOne({ alias, companyId }).lean()
     },
 
     async createTracker(data) {
@@ -59,7 +59,7 @@ module.exports = {
             await Tracker.create({
                 companyId,
                 serialNumber: tracker.serialNumber,
-                licensePlate: tracker.licensePlate || `#MIG-${tracker.serialNumber}`
+                alias: tracker.alias || `#MIG-${tracker.serialNumber}`
             })
         }
     },

--- a/track-api/src/fleet/fleet.routes.js
+++ b/track-api/src/fleet/fleet.routes.js
@@ -5,9 +5,9 @@ const service = require('./fleet.service')
 const router = express.Router()
 
 router.post('/trackers/add', auth, async (req, res) => {
-    const { userId, body: { serialNumber, licensePlate } } = req
+    const { userId, body: { serialNumber, alias } } = req
 
-    await service.addTracker(userId, { serialNumber, licensePlate })
+    await service.addTracker(userId, { serialNumber, alias })
     res.status(201).json({ message: 'Ok, Tracker added.' })
 })
 
@@ -32,17 +32,17 @@ router.get('/trackers/sn/:sn', auth, async (req, res) => {
     return res.json(tracker)
 })
 
-router.get('/trackers/lp/:lp', auth, async (req, res) => {
-    const { userId, params: { lp } } = req
+router.get('/trackers/alias/:alias', auth, async (req, res) => {
+    const { userId, params: { alias } } = req
 
-    const tracker = await service.retrieveTrackerByLicense(userId, lp)
+    const tracker = await service.retrieveTrackerByAlias(userId, alias)
     return res.json(tracker)
 })
 
 router.put('/trackers/:id/update', auth, async (req, res) => {
-    const { userId, params: { id }, body: { serialNumber, licensePlate } } = req
+    const { userId, params: { id }, body: { serialNumber, alias } } = req
 
-    await service.updateTracker(userId, id, { serialNumber, licensePlate })
+    await service.updateTracker(userId, id, { serialNumber, alias })
     res.status(201).json({ message: 'Ok, Tracker updated.' })
 })
 

--- a/track-api/src/fleet/fleet.service.js
+++ b/track-api/src/fleet/fleet.service.js
@@ -13,12 +13,15 @@ const fleetService = {
     addTracker(id, trackerData) {
         if (!trackerData) throw new InputError('incorrect tracker info')
 
-        let { serialNumber, licensePlate = '#IS-' + (Math.floor(Math.random() * (9999 - 1000)) + 1000).toString() + '-FAKE' } = trackerData
+        let { serialNumber, alias } = trackerData
+        if (!alias || (typeof alias === 'string' && !alias.trim())) {
+            alias = '#IS-' + (Math.floor(Math.random() * (9999 - 1000)) + 1000).toString() + '-FAKE'
+        }
 
         validate.arguments([
             { name: 'id', value: id, type: String, notEmpty: true },
             { name: 'serialNumber', value: serialNumber, type: String, notEmpty: true },
-            { name: 'licensePlate', value: licensePlate, type: String, notEmpty: true, optional: true }
+            { name: 'alias', value: alias, type: String, notEmpty: true, optional: true }
         ])
 
         return (async () => {
@@ -28,14 +31,14 @@ const fleetService = {
             await repo.syncLegacyTrackers(companyId, user.trackers || [])
 
             let plate = 0
-            if (licensePlate[0] !== '#') plate = await repo.findTrackerByLicensePlate(licensePlate)
-            if (plate) throw new LogicError(`License Plate ${licensePlate} already registered`)
+            if (alias[0] !== '#') plate = await repo.findTrackerByAlias(alias)
+            if (plate) throw new LogicError(`Alias ${alias} already registered`)
 
             const serial = await repo.findTrackerBySerial(serialNumber)
             if (serial) throw new LogicError(`Serial Number ${serialNumber} already registered`)
 
-            await repo.createTracker({ companyId, serialNumber, licensePlate })
-            user.trackers.push({ serialNumber, licensePlate })
+            await repo.createTracker({ companyId, serialNumber, alias })
+            user.trackers.push({ serialNumber, alias })
             await repo.saveUser(user)
         })()
     },
@@ -108,10 +111,10 @@ const fleetService = {
         })()
     },
 
-    retrieveTrackerByLicense(id, licensePlate) {
+    retrieveTrackerByAlias(id, alias) {
         validate.arguments([
             { name: 'id', value: id, type: String, notEmpty: true },
-            { name: 'licensePlate', value: licensePlate, type: String, notEmpty: true }
+            { name: 'alias', value: alias, type: String, notEmpty: true }
         ])
 
         return (async () => {
@@ -120,8 +123,8 @@ const fleetService = {
             const companyId = await ensureUserCompany(user)
             await repo.syncLegacyTrackers(companyId, user.trackers || [])
 
-            const tracker = await repo.findTrackerByLPAndCompany(licensePlate, companyId)
-            if (!tracker) throw new LogicError(`Tracker with License Plate ${licensePlate} doesn't exists`)
+            const tracker = await repo.findTrackerByAliasAndCompany(alias, companyId)
+            if (!tracker) throw new LogicError(`Tracker with alias ${alias} doesn't exists`)
             return tracker
         })()
     },
@@ -148,10 +151,10 @@ const fleetService = {
             }
             if (!tracker) throw new LogicError(`Tracker with id ${trackerID} doesn't exists`)
 
-            if (trackerData.licensePlate && trackerData.licensePlate[0] !== '#') {
-                const plate = await repo.findTrackerByLicensePlate(trackerData.licensePlate)
+            if (trackerData.alias && trackerData.alias[0] !== '#') {
+                const plate = await repo.findTrackerByAlias(trackerData.alias)
                 if (plate && plate._id.toString() !== trackerID) {
-                    throw new LogicError(`License Plate ${trackerData.licensePlate} already registered`)
+                    throw new LogicError(`Alias ${trackerData.alias} already registered`)
                 }
             }
 
@@ -164,13 +167,13 @@ const fleetService = {
 
             await repo.updateTrackerByIdAndCompany(tracker._id, companyId, {
                 serialNumber: trackerData.serialNumber || tracker.serialNumber,
-                licensePlate: trackerData.licensePlate || tracker.licensePlate
+                alias: trackerData.alias || tracker.alias
             })
 
             const legacy = user.trackers.id(trackerID) || user.trackers.find(item => item.serialNumber === tracker.serialNumber)
             if (legacy) {
                 legacy.serialNumber = trackerData.serialNumber || legacy.serialNumber
-                legacy.licensePlate = trackerData.licensePlate || legacy.licensePlate
+                legacy.alias = trackerData.alias || legacy.alias
                 await repo.saveUser(user)
             }
         })()

--- a/track-api/src/fleet/fleet.service.spec.js
+++ b/track-api/src/fleet/fleet.service.spec.js
@@ -23,12 +23,12 @@ describe('fleetService', () => {
         })
 
         it('should succeed on correct tracker data [FULL]', async () => {
-            const trackerData = { serialNumber: '1234567890', licensePlate: '1234-ABC' }
+            const trackerData = { serialNumber: '1234567890', alias: '1234-ABC' }
             await service.addTracker(user.id, trackerData)
             const resp = await User.findById(user.id)
             const pos = resp.trackers.length - 1
             expect(resp.trackers[pos].serialNumber).toBe('1234567890')
-            expect(resp.trackers[pos].licensePlate).toBe('1234-ABC')
+            expect(resp.trackers[pos].alias).toBe('1234-ABC')
         })
 
         it('should succeed on correct data [without license plate]', async () => {
@@ -37,7 +37,7 @@ describe('fleetService', () => {
             const resp = await User.findById(user.id)
             const pos = resp.trackers.length - 1
             expect(resp.trackers[pos].serialNumber).toBe('1234567890')
-            expect(resp.trackers[pos].licensePlate).toBeDefined()
+            expect(resp.trackers[pos].alias).toBeDefined()
         })
 
         it('should fail on incorrect id user', async () => {
@@ -99,14 +99,14 @@ describe('fleetService', () => {
 
         it('should fail on add existing tracker license plate', async () => {
             const _serialNumber = '1234500000'
-            const _licensePlate = '1234-SKY'
+            const _alias = '1234-SKY'
             const __serialNumber = '1231456456'
             try {
-                await service.addTracker(user.id, { serialNumber: _serialNumber, licensePlate: _licensePlate })
-                await service.addTracker(user.id, { serialNumber: __serialNumber, licensePlate: _licensePlate })
+                await service.addTracker(user.id, { serialNumber: _serialNumber, alias: _alias })
+                await service.addTracker(user.id, { serialNumber: __serialNumber, alias: _alias })
             } catch (error) {
                 expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`License Plate ${_licensePlate} already registered`)
+                expect(error.message).toBe(`Alias ${_alias} already registered`)
             }
         })
     })
@@ -116,8 +116,8 @@ describe('fleetService', () => {
 
         beforeEach(async () => {
             _password = await argon2.hash(password)
-            const trackerData = { serialNumber: '1234567890', licensePlate: '1234-ABC' }
-            const trackerData2 = { serialNumber: '12332100', licensePlate: '9089-POP' }
+            const trackerData = { serialNumber: '1234567890', alias: '1234-ABC' }
+            const trackerData2 = { serialNumber: '12332100', alias: '9089-POP' }
             user = await User.create({ name, surname, email, password: _password, trackers: [trackerData, trackerData2] })
             _user = await User.create({ name, surname, email: '123@123.ccc', password: _password })
         })
@@ -149,8 +149,8 @@ describe('fleetService', () => {
         beforeEach(async () => {
             _password = await argon2.hash(password)
             user = await User.create({ name, surname, email, password: _password, trackers: [
-                { serialNumber: '1234567890', licensePlate: '1234-ABC' },
-                { serialNumber: '12332100', licensePlate: '9089-POP' }
+                { serialNumber: '1234567890', alias: '1234-ABC' },
+                { serialNumber: '12332100', alias: '9089-POP' }
             ]})
             _user = await User.create({ name, surname, email: '123@123.ccc', password: _password })
         })
@@ -158,7 +158,7 @@ describe('fleetService', () => {
         it('should succeed on correct id from existing user', async () => {
             const data = await service.retrieveTracker(user.id, user.trackers[0].id)
             expect(data.serialNumber).toBe('1234567890')
-            expect(data.licensePlate).toBe('1234-ABC')
+            expect(data.alias).toBe('1234-ABC')
         })
 
         it('should fail on incorrect user id', async () => {
@@ -197,8 +197,8 @@ describe('fleetService', () => {
         beforeEach(async () => {
             _password = await argon2.hash(password)
             user = await User.create({ name, surname, email, password: _password, trackers: [
-                { serialNumber: '1234567890', licensePlate: '1234-ABC' },
-                { serialNumber: '12332100', licensePlate: '9089-POP' }
+                { serialNumber: '1234567890', alias: '1234-ABC' },
+                { serialNumber: '12332100', alias: '9089-POP' }
             ]})
             _user = await User.create({ name, surname, email: '123@123.ccc', password: _password })
         })
@@ -206,7 +206,7 @@ describe('fleetService', () => {
         it('should succeed on correct id from existing user', async () => {
             const data = await service.retrieveTrackerBySN(user.id, '1234567890')
             expect(data.serialNumber).toBe('1234567890')
-            expect(data.licensePlate).toBe('1234-ABC')
+            expect(data.alias).toBe('1234-ABC')
         })
 
         it('should fail on incorrect user id', async () => {
@@ -239,50 +239,50 @@ describe('fleetService', () => {
         })
     })
 
-    describe('retrieve Tracker by License Plate', () => {
+    describe('retrieve Tracker by Alias', () => {
         let user, _user, _password
 
         beforeEach(async () => {
             _password = await argon2.hash(password)
             user = await User.create({ name, surname, email, password: _password, trackers: [
-                { serialNumber: '1234567890', licensePlate: '1234-ABC' },
-                { serialNumber: '12332100', licensePlate: '9089-POP' }
+                { serialNumber: '1234567890', alias: '1234-ABC' },
+                { serialNumber: '12332100', alias: '9089-POP' }
             ]})
             _user = await User.create({ name, surname, email: '123@123.ccc', password: _password })
         })
 
         it('should succeed on correct id from existing user', async () => {
-            const data = await service.retrieveTrackerByLicense(user.id, '1234-ABC')
+            const data = await service.retrieveTrackerByAlias(user.id, '1234-ABC')
             expect(data.serialNumber).toBe('1234567890')
-            expect(data.licensePlate).toBe('1234-ABC')
+            expect(data.alias).toBe('1234-ABC')
         })
 
         it('should fail on incorrect user id', async () => {
             const wrongId = '5cb9998f2e59ee0009eac02c'
             try {
-                await service.retrieveTrackerByLicense(wrongId, '1234-ABC')
+                await service.retrieveTrackerByAlias(wrongId, '1234-ABC')
             } catch (error) {
                 expect(error).toBeInstanceOf(LogicError)
                 expect(error.message).toBe(`user with id ${wrongId} doesn't exists`)
             }
         })
 
-        it('should fail on user with wrong Tracker License', async () => {
+        it('should fail on user with wrong Tracker alias', async () => {
             const trackerLicense = 'FAKE_FAKE'
             try {
-                await service.retrieveTrackerByLicense(user.id, trackerLicense)
+                await service.retrieveTrackerByAlias(user.id, trackerLicense)
             } catch (error) {
                 expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`Tracker with License Plate ${trackerLicense} doesn't exists`)
+                expect(error.message).toBe(`Tracker with alias ${trackerLicense} doesn't exists`)
             }
         })
 
-        it('should fail on undefined License', async () => {
+        it('should fail on undefined alias', async () => {
             try {
-                await service.retrieveTrackerByLicense(user.id, undefined)
+                await service.retrieveTrackerByAlias(user.id, undefined)
             } catch (error) {
                 expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`licensePlate is not optional`)
+                expect(error.message).toBe(`alias is not optional`)
             }
         })
     })
@@ -294,17 +294,17 @@ describe('fleetService', () => {
             _password = await argon2.hash(password)
             _user = await User.create({ name, surname, email: '12__3@123.com', password: _password })
             user = await User.create({ name, surname, email, password: _password, trackers: [
-                { serialNumber: '1234567890', licensePlate: '1234-ABC' },
-                { serialNumber: '0987654321', licensePlate: '0909-CXD' }
+                { serialNumber: '1234567890', alias: '1234-ABC' },
+                { serialNumber: '0987654321', alias: '0909-CXD' }
             ]})
         })
 
         it('should succeed on correct id from existing user', async () => {
-            const _trackerData = { serialNumber: '09-UPDATE-91', licensePlate: '0909-UPDATE' }
+            const _trackerData = { serialNumber: '09-UPDATE-91', alias: '0909-UPDATE' }
             await service.updateTracker(user.id, user.trackers[0].id, _trackerData)
             const data = await User.findById(user.id)
             expect(data.trackers[0].serialNumber).toBe('09-UPDATE-91')
-            expect(data.trackers[0].licensePlate).toBe('0909-UPDATE')
+            expect(data.trackers[0].alias).toBe('0909-UPDATE')
         })
 
         it('should succeed on correct id from existing user [only serialnumber]', async () => {
@@ -312,15 +312,15 @@ describe('fleetService', () => {
             await service.updateTracker(user.id, user.trackers[0].id, _trackerData)
             const data = await User.findById(user.id)
             expect(data.trackers[0].serialNumber).toBe('09-UPDATE-91')
-            expect(data.trackers[0].licensePlate).toBe('1234-ABC')
+            expect(data.trackers[0].alias).toBe('1234-ABC')
         })
 
-        it('should succeed on correct id from existing user [only licenseplate]', async () => {
-            const _trackerData = { licensePlate: '0909-UPDATE' }
+        it('should succeed on correct id from existing user [only alias]', async () => {
+            const _trackerData = { alias: '0909-UPDATE' }
             await service.updateTracker(user.id, user.trackers[0].id, _trackerData)
             const data = await User.findById(user.id)
             expect(data.trackers[0].serialNumber).toBe('1234567890')
-            expect(data.trackers[0].licensePlate).toBe('0909-UPDATE')
+            expect(data.trackers[0].alias).toBe('0909-UPDATE')
         })
 
         it('should fail on incorrect user id', async () => {
@@ -369,8 +369,8 @@ describe('fleetService', () => {
             _password = await argon2.hash(password)
             _user = await User.create({ name, surname, email: '12__3@123.com', password: _password })
             user = await User.create({ name, surname, email, password: _password, trackers: [
-                { serialNumber: '1234567890', licensePlate: '1234-ABC' },
-                { serialNumber: '0987654321', licensePlate: '0909-CXD' }
+                { serialNumber: '1234567890', alias: '1234-ABC' },
+                { serialNumber: '0987654321', alias: '0909-CXD' }
             ]})
         })
 
@@ -378,7 +378,7 @@ describe('fleetService', () => {
             await service.deleteTracker(user.id, user.trackers[0].id)
             const data = await User.findById(user.id)
             expect(data.trackers.length).toBe(1)
-            expect(data.trackers[0].licensePlate).toBe('0909-CXD')
+            expect(data.trackers[0].alias).toBe('0909-CXD')
         })
 
         it('should fail on incorrect user id', async () => {

--- a/track-api/src/graphql/resolvers/backoffice.resolver.js
+++ b/track-api/src/graphql/resolvers/backoffice.resolver.js
@@ -126,6 +126,21 @@ const backofficeResolver = {
 
     /**
      * @param {unknown} _
+     * @param {{ input: { serialNumber: string, alias?: string, companyId: string } }} args
+     * @param {{ userId: string|null }} ctx
+     */
+    async backofficeCreateTracker(_, { input }, ctx) {
+      const userId = requireAuth(ctx)
+      try {
+        await service.createTracker(userId, input)
+        return { success: true, message: 'Ok, tracker created.' }
+      } catch (err) {
+        throw toGraphQLError(/** @type {Error} */ (err))
+      }
+    },
+
+    /**
+     * @param {unknown} _
      * @param {{ id: string, input: { name?: string, surname?: string, email?: string, language?: string, role?: string, companyId?: string, permissionKeys?: string[] } }} args
      * @param {{ userId: string|null }} ctx
      */

--- a/track-api/src/graphql/resolvers/fleet.resolver.js
+++ b/track-api/src/graphql/resolvers/fleet.resolver.js
@@ -23,7 +23,7 @@ const fleetResolver = {
           items: rows.map(t => ({
             id: t._id.toString(),
             serialNumber: t.serialNumber,
-            licensePlate: t.licensePlate || null
+            alias: t.alias || null
           })),
           totalCount: Number(totalCount || 0)
         }
@@ -42,7 +42,7 @@ const fleetResolver = {
       try {
         await requireAccess(userId, { feature: 'fleet', permission: 'fleet.read' })
         const t = await service.retrieveTracker(userId, id)
-        return { id: t._id.toString(), serialNumber: t.serialNumber, licensePlate: t.licensePlate || null }
+        return { id: t._id.toString(), serialNumber: t.serialNumber, alias: t.alias || null }
       } catch (err) {
         throw toGraphQLError(/** @type {Error} */ (err))
       }
@@ -58,7 +58,7 @@ const fleetResolver = {
       try {
         await requireAccess(userId, { feature: 'fleet', permission: 'fleet.read' })
         const t = await service.retrieveTrackerBySN(userId, serialNumber)
-        return { id: t._id.toString(), serialNumber: t.serialNumber, licensePlate: t.licensePlate || null }
+        return { id: t._id.toString(), serialNumber: t.serialNumber, alias: t.alias || null }
       } catch (err) {
         throw toGraphQLError(/** @type {Error} */ (err))
       }
@@ -66,15 +66,15 @@ const fleetResolver = {
 
     /**
      * @param {unknown} _
-     * @param {{ licensePlate: string }} args
+     * @param {{ alias: string }} args
      * @param {{ userId: string|null }} ctx
      */
-    async trackerByLP(_, { licensePlate }, ctx) {
+    async trackerByAlias(_, { alias }, ctx) {
       const userId = requireAuth(ctx)
       try {
         await requireAccess(userId, { feature: 'fleet', permission: 'fleet.read' })
-        const t = await service.retrieveTrackerByLicense(userId, licensePlate)
-        return { id: t._id.toString(), serialNumber: t.serialNumber, licensePlate: t.licensePlate || null }
+        const t = await service.retrieveTrackerByAlias(userId, alias)
+        return { id: t._id.toString(), serialNumber: t.serialNumber, alias: t.alias || null }
       } catch (err) {
         throw toGraphQLError(/** @type {Error} */ (err))
       }
@@ -84,7 +84,7 @@ const fleetResolver = {
   Mutation: {
     /**
      * @param {unknown} _
-     * @param {{ input: { serialNumber: string, licensePlate?: string } }} args
+     * @param {{ input: { serialNumber: string, alias?: string } }} args
      * @param {{ userId: string|null }} ctx
      */
     async addTracker(_, { input }, ctx) {
@@ -100,7 +100,7 @@ const fleetResolver = {
 
     /**
      * @param {unknown} _
-     * @param {{ id: string, input: { serialNumber?: string, licensePlate?: string } }} args
+     * @param {{ id: string, input: { serialNumber?: string, alias?: string } }} args
      * @param {{ userId: string|null }} ctx
      */
     async updateTracker(_, { id, input }, ctx) {

--- a/track-api/src/graphql/resolvers/tracking.resolver.js
+++ b/track-api/src/graphql/resolvers/tracking.resolver.js
@@ -22,9 +22,9 @@ const trackingResolver = {
           latitude: t.latitude,
           longitude: t.longitude,
           speed: t.speed,
-          status: t.status,
+          status: toApiStatus(t.status),
           date: t.date,
-          licensePlate: t.licensePlate || null
+          alias: t.alias || null
         }))
       } catch (err) {
         throw toGraphQLError(err)
@@ -48,7 +48,7 @@ const trackingResolver = {
           latitude: track.latitude,
           longitude: track.longitude,
           speed: track.speed,
-          status: track.status,
+          status: toApiStatus(track.status),
           date: track.date
         }
       } catch (err) {
@@ -77,7 +77,7 @@ const trackingResolver = {
           latitude: t.latitude,
           longitude: t.longitude,
           speed: t.speed,
-          status: t.status,
+          status: toApiStatus(t.status),
           date: t.date
         }))
       } catch (err) {
@@ -104,3 +104,8 @@ const trackingResolver = {
 }
 
 module.exports = trackingResolver
+
+function toApiStatus(value) {
+  if (value === 0 || value === '0' || value === 'OFF') return 'OFF'
+  return 'ON'
+}

--- a/track-api/src/graphql/schema.graphql
+++ b/track-api/src/graphql/schema.graphql
@@ -49,7 +49,7 @@ type PagedBackofficeUsers {
 type Tracker {
   id: ID!
   serialNumber: String!
-  licensePlate: String
+  alias: String
 }
 
 type Track {
@@ -69,7 +69,7 @@ type LiveTrack {
   speed: Float!
   status: String!
   date: DateTime!
-  licensePlate: String
+  alias: String
 }
 
 type POI {
@@ -143,12 +143,12 @@ input BackofficeUpdateUserInput {
 
 input AddTrackerInput {
   serialNumber: String!
-  licensePlate: String
+  alias: String
 }
 
 input UpdateTrackerInput {
   serialNumber: String
-  licensePlate: String
+  alias: String
 }
 
 input AddPOIInput {
@@ -170,7 +170,7 @@ type Query {
   trackers(offset: Int = 0, limit: Int = 20): PagedTrackers!
   tracker(id: ID!): Tracker!
   trackerBySN(serialNumber: String!): Tracker!
-  trackerByLP(licensePlate: String!): Tracker!
+  trackerByAlias(alias: String!): Tracker!
   lastTracks: [LiveTrack!]!
   lastTrack(trackerId: ID!): Track
   trackRange(trackerId: ID!, start: DateTime!, end: DateTime!): [Track!]!

--- a/track-api/src/graphql/schema.graphql
+++ b/track-api/src/graphql/schema.graphql
@@ -141,6 +141,12 @@ input BackofficeUpdateUserInput {
   permissionKeys: [String!]
 }
 
+input BackofficeCreateTrackerInput {
+  serialNumber: String!
+  alias: String
+  companyId: ID!
+}
+
 input AddTrackerInput {
   serialNumber: String!
   alias: String
@@ -201,6 +207,7 @@ type Mutation {
     input: BackofficeUpdateCompanyInput!
   ): MutationResult!
   backofficeCreateUser(input: BackofficeCreateUserInput!): MutationResult!
+  backofficeCreateTracker(input: BackofficeCreateTrackerInput!): MutationResult!
   backofficeUpdateUser(
     id: ID!
     input: BackofficeUpdateUserInput!

--- a/track-api/src/tracking/simulator-retention.job.js
+++ b/track-api/src/tracking/simulator-retention.job.js
@@ -1,24 +1,10 @@
 const repo = require('./tracking.repository')
 
 const DAY_MS = 24 * 60 * 60 * 1000
-const MINUTE_MS = 60 * 1000
-const DEFAULT_RETENTION_DAYS = 60
-const DEFAULT_INTERVAL_MINUTES = 60
-const DEFAULT_INITIAL_DELAY_MINUTES = 2
 const DEFAULT_SIMULATOR_SERIALS = Array.from(
     { length: 30 },
     (_, index) => String(9900111000 + index + 1)
 )
-
-function parsePositiveInteger(rawValue, fallback) {
-    const parsed = Number.parseInt(rawValue, 10)
-    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
-}
-
-function parseNonNegativeInteger(rawValue, fallback) {
-    const parsed = Number.parseInt(rawValue, 10)
-    return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback
-}
 
 function parseSimulatorSerials(rawValue) {
     if (!rawValue || typeof rawValue !== 'string') return [...DEFAULT_SIMULATOR_SERIALS]
@@ -39,14 +25,14 @@ function parseEnabled(rawValue) {
 function getRetentionConfig(env = process.env) {
     return {
         enabled: parseEnabled(env.SIM_TRACK_CLEANUP_ENABLED),
-        retentionDays: parsePositiveInteger(env.SIM_TRACK_RETENTION_DAYS, DEFAULT_RETENTION_DAYS),
-        intervalMinutes: parsePositiveInteger(env.SIM_TRACK_CLEANUP_INTERVAL_MINUTES, DEFAULT_INTERVAL_MINUTES),
-        initialDelayMinutes: parseNonNegativeInteger(
-            env.SIM_TRACK_CLEANUP_INITIAL_DELAY_MINUTES,
-            DEFAULT_INITIAL_DELAY_MINUTES
-        ),
         simulatorSerials: parseSimulatorSerials(env.SIM_TRACK_SERIALS)
     }
+}
+
+function getMsUntilNextMidnight(now = new Date()) {
+    const next = new Date(now)
+    next.setHours(24, 0, 0, 0)
+    return next.getTime() - now.getTime()
 }
 
 async function runCleanup(config = getRetentionConfig(), logger = console) {
@@ -54,14 +40,13 @@ async function runCleanup(config = getRetentionConfig(), logger = console) {
         return { skipped: true, deletedCount: 0 }
     }
 
-    const cutoff = new Date(Date.now() - config.retentionDays * DAY_MS)
-    const deletedCount = await repo.deleteOlderThanBySerials(config.simulatorSerials, cutoff)
+    const deletedCount = await repo.deleteBySerials(config.simulatorSerials)
 
     logger.log(
-        `[simulator-retention] deleted=${deletedCount} cutoff=${cutoff.toISOString()} serials=${config.simulatorSerials.length}`
+        `[simulator-retention] deleted=${deletedCount} serials=${config.simulatorSerials.length}`
     )
 
-    return { skipped: false, deletedCount, cutoff }
+    return { skipped: false, deletedCount }
 }
 
 function startSimulatorTrackRetentionJob({ env = process.env, logger = console } = {}) {
@@ -78,27 +63,28 @@ function startSimulatorTrackRetentionJob({ env = process.env, logger = console }
         })
     }
 
-    const delayMs = config.initialDelayMinutes * MINUTE_MS
-    const startMessage = delayMs > 0
-        ? `[simulator-retention] first cleanup in ${config.initialDelayMinutes}m; interval=${config.intervalMinutes}m`
-        : `[simulator-retention] first cleanup immediately; interval=${config.intervalMinutes}m`
-    logger.log(startMessage)
+    const delayMs = getMsUntilNextMidnight()
+    const firstRunAt = new Date(Date.now() + delayMs).toISOString()
+    logger.log(`[simulator-retention] first cleanup at ${firstRunAt}; interval=24h`)
 
-    const firstRunTimer = setTimeout(execute, delayMs)
+    let timer = null
+    const firstRunTimer = setTimeout(() => {
+        execute()
+        timer = setInterval(execute, DAY_MS)
+        if (typeof timer.unref === 'function') timer.unref()
+    }, delayMs)
     if (typeof firstRunTimer.unref === 'function') firstRunTimer.unref()
-
-    const timer = setInterval(execute, config.intervalMinutes * MINUTE_MS)
-    if (typeof timer.unref === 'function') timer.unref()
 
     return () => {
         clearTimeout(firstRunTimer)
-        clearInterval(timer)
+        if (timer) clearInterval(timer)
     }
 }
 
 module.exports = {
     DEFAULT_SIMULATOR_SERIALS,
     getRetentionConfig,
+    getMsUntilNextMidnight,
     runCleanup,
     startSimulatorTrackRetentionJob
 }

--- a/track-api/src/tracking/simulator-retention.job.spec.js
+++ b/track-api/src/tracking/simulator-retention.job.spec.js
@@ -1,6 +1,7 @@
 const { models: { Track } } = require('track-data')
 const {
     getRetentionConfig,
+    getMsUntilNextMidnight,
     runCleanup
 } = require('./simulator-retention.job')
 
@@ -14,9 +15,6 @@ describe('simulator retention job', () => {
             const config = getRetentionConfig({})
 
             expect(config.enabled).toBe(true)
-            expect(config.retentionDays).toBe(60)
-            expect(config.intervalMinutes).toBe(60)
-            expect(config.initialDelayMinutes).toBe(2)
             expect(config.simulatorSerials).toHaveLength(30)
             expect(config.simulatorSerials[0]).toBe('9900111001')
             expect(config.simulatorSerials[29]).toBe('9900111030')
@@ -25,52 +23,48 @@ describe('simulator retention job', () => {
         it('parses custom env values', () => {
             const config = getRetentionConfig({
                 SIM_TRACK_CLEANUP_ENABLED: 'true',
-                SIM_TRACK_RETENTION_DAYS: '90',
-                SIM_TRACK_CLEANUP_INTERVAL_MINUTES: '15',
-                SIM_TRACK_CLEANUP_INITIAL_DELAY_MINUTES: '5',
                 SIM_TRACK_SERIALS: 'SN-1, SN-2, SN-1'
             })
 
-            expect(config.retentionDays).toBe(90)
-            expect(config.intervalMinutes).toBe(15)
-            expect(config.initialDelayMinutes).toBe(5)
             expect(config.simulatorSerials).toEqual(['SN-1', 'SN-2'])
         })
     })
 
+    describe('getMsUntilNextMidnight', () => {
+        it('returns milliseconds until next local midnight', () => {
+            const now = new Date('2026-04-16T10:30:00')
+            const ms = getMsUntilNextMidnight(now)
+            expect(ms).toBe(13.5 * 60 * 60 * 1000)
+        })
+    })
+
     describe('runCleanup', () => {
-        it('deletes only old tracks from simulator serials', async () => {
+        it('deletes all tracks from simulator serials', async () => {
             const now = Date.now()
             const oldDate = new Date(now - 61 * 24 * 60 * 60 * 1000)
             const recentDate = new Date(now - 10 * 24 * 60 * 60 * 1000)
 
-            await Track.create({ serialNumber: '9900110011', latitude: 41.39, longitude: 2.15, speed: 40, status: 'ON', date: oldDate })
-            await Track.create({ serialNumber: '9900110011', latitude: 41.40, longitude: 2.16, speed: 50, status: 'ON', date: recentDate })
-            await Track.create({ serialNumber: 'REAL-0001', latitude: 41.50, longitude: 2.20, speed: 60, status: 'ON', date: oldDate })
+            await Track.create({ serialNumber: '9900110011', latitude: 41.39, longitude: 2.15, speed: 40, status: 1, date: oldDate })
+            await Track.create({ serialNumber: '9900110011', latitude: 41.40, longitude: 2.16, speed: 50, status: 1, date: recentDate })
+            await Track.create({ serialNumber: 'REAL-0001', latitude: 41.50, longitude: 2.20, speed: 60, status: 1, date: oldDate })
 
             const result = await runCleanup({
                 enabled: true,
-                retentionDays: 60,
-                intervalMinutes: 60,
-                initialDelayMinutes: 0,
                 simulatorSerials: ['9900110011']
             }, { log: () => {}, error: () => {} })
 
             expect(result.skipped).toBe(false)
-            expect(result.deletedCount).toBe(1)
+            expect(result.deletedCount).toBe(2)
 
             const simCount = await Track.countDocuments({ serialNumber: '9900110011' })
             const realCount = await Track.countDocuments({ serialNumber: 'REAL-0001' })
-            expect(simCount).toBe(1)
+            expect(simCount).toBe(0)
             expect(realCount).toBe(1)
         })
 
         it('skips cleanup when disabled', async () => {
             const result = await runCleanup({
                 enabled: false,
-                retentionDays: 60,
-                intervalMinutes: 60,
-                initialDelayMinutes: 0,
                 simulatorSerials: ['9900110011']
             }, { log: () => {}, error: () => {} })
 

--- a/track-api/src/tracking/tracking.repository.js
+++ b/track-api/src/tracking/tracking.repository.js
@@ -20,8 +20,8 @@ module.exports = {
     async findLastBySerials(serialNumbers) {
         const docs = await Track.aggregate([
             { $match: { serialNumber: { $in: serialNumbers } } },
-            { $sort: { serialNumber: 1, date: -1 } },
-            { $group: { _id: '$serialNumber', doc: { $first: '$$ROOT' } } }
+            { $sort: { serialNumber: 1, date: 1 } },
+            { $group: { _id: '$serialNumber', doc: { $last: '$$ROOT' } } }
         ])
         const map = new Map()
         docs.forEach(({ _id, doc }) => map.set(_id, doc))
@@ -57,7 +57,7 @@ module.exports = {
             await Tracker.create({
                 companyId,
                 serialNumber: tracker.serialNumber,
-                licensePlate: tracker.licensePlate || `#MIG-${tracker.serialNumber}`
+                alias: tracker.alias || `#MIG-${tracker.serialNumber}`
             })
         }
     },
@@ -66,6 +66,14 @@ module.exports = {
         const result = await Track.deleteMany({
             serialNumber: { $in: serialNumbers },
             date: { $lt: cutoffDate }
+        })
+
+        return result.deletedCount || 0
+    },
+
+    async deleteBySerials(serialNumbers) {
+        const result = await Track.deleteMany({
+            serialNumber: { $in: serialNumbers }
         })
 
         return result.deletedCount || 0

--- a/track-api/src/tracking/tracking.service.js
+++ b/track-api/src/tracking/tracking.service.js
@@ -21,6 +21,8 @@ const trackingService = {
         if (typeof trackData.status === 'undefined') trackData.status = 'ON'
 
         let { serialNumber, latitude, longitude, speed, status, date } = trackData
+        status = normalizeIncomingStatus(status)
+        ;({ latitude, longitude, speed } = compactTelemetry({ latitude, longitude, speed }))
 
         validate.arguments([
             { name: 'id', value: userId, type: String, notEmpty: true },
@@ -28,7 +30,7 @@ const trackingService = {
             { name: 'latitude', value: latitude, type: Number, notEmpty: true },
             { name: 'longitude', value: longitude, type: Number, notEmpty: true },
             { name: 'speed', value: speed, type: Number, notEmpty: true, optional: true },
-            { name: 'status', value: status, type: String, notEmpty: true, optional: true },
+            { name: 'status', value: status, type: Number, notEmpty: true, optional: true },
             { name: 'date', value: date, type: String, notEmpty: true, optional: true }
         ])
         validateTelemetry({ latitude, longitude, speed, status })
@@ -55,13 +57,15 @@ const trackingService = {
         if (typeof trackData.status === 'undefined') trackData.status = 'ON'
 
         let { serialNumber, latitude, longitude, speed, status, date } = trackData
+        status = normalizeIncomingStatus(status)
+        ;({ latitude, longitude, speed } = compactTelemetry({ latitude, longitude, speed }))
 
         validate.arguments([
             { name: 'serialNumber', value: serialNumber, type: String, notEmpty: true },
             { name: 'latitude', value: latitude, type: Number, notEmpty: true },
             { name: 'longitude', value: longitude, type: Number, notEmpty: true },
             { name: 'speed', value: speed, type: Number, notEmpty: true, optional: true },
-            { name: 'status', value: status, type: String, notEmpty: true, optional: true },
+            { name: 'status', value: status, type: Number, notEmpty: true, optional: true },
             { name: 'date', value: date, type: String, notEmpty: true, optional: true }
         ])
         validateTelemetry({ latitude, longitude, speed, status })
@@ -90,9 +94,9 @@ const trackingService = {
                     latitude,
                     longitude,
                     speed,
-                    status,
+                    status: denormalizeStoredStatus(status),
                     date: new Date().toISOString(),
-                    licensePlate: tracker.licensePlate || null
+                    alias: tracker.alias || null
                 }]
             })
 
@@ -119,7 +123,8 @@ const trackingService = {
             }
             if (!tracker) throw new LogicError(`Tracker with id ${trackerID} doesn't exists`)
 
-            return repo.findLastBySerial(tracker.serialNumber)
+            const lastTrack = await repo.findLastBySerial(tracker.serialNumber)
+            return mapTrackStatusToApi(lastTrack)
         })()
     },
 
@@ -142,12 +147,13 @@ const trackingService = {
             const serialNumbers = companyTrackers.map(t => t.serialNumber)
             const lastBySerial = await repo.findLastBySerials(serialNumbers)
 
-            // Build a lookup map: serialNumber → licensePlate
-            const lpMap = new Map(companyTrackers.map(t => [t.serialNumber, t.licensePlate]))
+            // Build a lookup map: serialNumber → alias
+            const aliasMap = new Map(companyTrackers.map(t => [t.serialNumber, t.alias]))
 
             return [...lastBySerial.entries()].map(([sn, track]) => ({
                 ...track,
-                licensePlate: lpMap.get(sn) || null
+                status: denormalizeStoredStatus(track.status),
+                alias: aliasMap.get(sn) || null
             }))
         })()
     },
@@ -182,7 +188,7 @@ const trackingService = {
                 throw new LogicError(`Tracker without tracks between ${startTime.toISOString()} and ${endTime.toISOString()}`)
             }
 
-            return rangeTracks
+            return rangeTracks.map(mapTrackStatusToApi)
         })()
     }
 }
@@ -200,9 +206,40 @@ function validateTelemetry({ latitude, longitude, speed, status }) {
         throw new InputError('speed out of range')
     }
 
-    if (!['ON', 'OFF'].includes(status)) {
+    if (status !== 0 && status !== 1) {
         throw new InputError('invalid status')
     }
+}
+
+function roundTo(value, decimals) {
+    const factor = 10 ** decimals
+    return Math.round(value * factor) / factor
+}
+
+function compactTelemetry({ latitude, longitude, speed }) {
+    return {
+        latitude: roundTo(latitude, 5),
+        longitude: roundTo(longitude, 5),
+        speed: roundTo(speed, 1)
+    }
+}
+
+function normalizeIncomingStatus(status) {
+    if (status === 1 || status === '1' || status === true) return 1
+    if (status === 0 || status === '0' || status === false) return 0
+    const normalized = String(status || '').trim().toUpperCase()
+    if (normalized === 'ON') return 1
+    if (normalized === 'OFF') return 0
+    throw new InputError('invalid status')
+}
+
+function denormalizeStoredStatus(status) {
+    return status === 0 || status === '0' ? 'OFF' : 'ON'
+}
+
+function mapTrackStatusToApi(track) {
+    if (!track) return track
+    return { ...track, status: denormalizeStoredStatus(track.status) }
 }
 
 module.exports = trackingService

--- a/track-api/src/tracking/tracking.service.spec.js
+++ b/track-api/src/tracking/tracking.service.spec.js
@@ -26,8 +26,8 @@ describe('trackingService', () => {
             lat = -80 + Math.random() * 160
             lon = Math.random() * 10
             _password = await argon2.hash(password)
-            trackerData2 = { serialNumber: '1234567890', licensePlate: '1234-ABC' }
-            trackerData = { serialNumber: '1234567123', licensePlate: '1244-ABC' }
+            trackerData2 = { serialNumber: '1234567890', alias: '1234-ABC' }
+            trackerData = { serialNumber: '1234567123', alias: '1244-ABC' }
             user = await User.create({ name, surname, email, password: _password, trackers: [trackerData, trackerData2] })
         })
 
@@ -37,14 +37,14 @@ describe('trackingService', () => {
                 latitude: lat,
                 longitude: lon,
                 speed: 123.21,
-                status: 'OFF',
+                status: 0,
                 date: new Date().toISOString()
             }
             await trackingService.addTrack(user.id, trackData)
             const saved = await Track.findOne({ serialNumber: '1234567890' })
             expect(saved).toBeDefined()
-            expect(saved.speed).toBe(123.21)
-            expect(saved.status).toBe('OFF')
+            expect(saved.speed).toBe(123.2)
+            expect(saved.status).toBe(0)
         })
 
         it('should succeed on correct track partial data (defaults speed=0, status=ON)', async () => {
@@ -58,12 +58,12 @@ describe('trackingService', () => {
             const saved = await Track.findOne({ serialNumber: '1234567890' })
             expect(saved).toBeDefined()
             expect(saved.speed).toBe(0)
-            expect(saved.status).toBe('ON')
+            expect(saved.status).toBe(1)
         })
 
         it('should fail on incorrect id user', async () => {
             const wrongId = '5cb9998f2e59ee0009eac02c'
-            const trackData = { serialNumber: '1234567890', latitude: lat, longitude: lon, speed: 1, status: 'ON', date: new Date().toISOString() }
+            const trackData = { serialNumber: '1234567890', latitude: lat, longitude: lon, speed: 1, status: 1, date: new Date().toISOString() }
             try {
                 await trackingService.addTrack(wrongId, trackData)
             } catch (error) {
@@ -73,7 +73,7 @@ describe('trackingService', () => {
         })
 
         it('should fail on undefined id user', async () => {
-            const trackData = { serialNumber: '1234567890', latitude: lat, longitude: lon, speed: 1, status: 'ON', date: new Date().toISOString() }
+            const trackData = { serialNumber: '1234567890', latitude: lat, longitude: lon, speed: 1, status: 1, date: new Date().toISOString() }
             try {
                 await trackingService.addTrack(undefined, trackData)
             } catch (error) {
@@ -83,7 +83,7 @@ describe('trackingService', () => {
         })
 
         it('should fail on null id user', async () => {
-            const trackData = { serialNumber: '1234567890', latitude: lat, longitude: lon, speed: 1, status: 'ON', date: new Date().toISOString() }
+            const trackData = { serialNumber: '1234567890', latitude: lat, longitude: lon, speed: 1, status: 1, date: new Date().toISOString() }
             try {
                 await trackingService.addTrack(null, trackData)
             } catch (error) {
@@ -93,7 +93,7 @@ describe('trackingService', () => {
         })
 
         it('should fail on unexisting serial number tracker', async () => {
-            const trackData = { serialNumber: '000_NO_EXIST', latitude: lat, longitude: lon, speed: 1, status: 'ON', date: new Date().toISOString() }
+            const trackData = { serialNumber: '000_NO_EXIST', latitude: lat, longitude: lon, speed: 1, status: 1, date: new Date().toISOString() }
             try {
                 await trackingService.addTrack(user.id, trackData)
             } catch (error) {
@@ -131,8 +131,8 @@ describe('trackingService', () => {
             lat = -80 + Math.random() * 160
             lon = Math.random() * 10
             _password = await argon2.hash(password)
-            trackerData2 = { serialNumber: '1234567890', licensePlate: '1234-ABC' }
-            trackerData = { serialNumber: '1234567123', licensePlate: '1244-ABC' }
+            trackerData2 = { serialNumber: '1234567890', alias: '1234-ABC' }
+            trackerData = { serialNumber: '1234567123', alias: '1244-ABC' }
             user = await User.create({ name, surname, email, password: _password, trackers: [trackerData, trackerData2] })
         })
 
@@ -145,7 +145,7 @@ describe('trackingService', () => {
                 latitude: lat,
                 longitude: lon,
                 speed: 55,
-                status: 'ON',
+                status: 1,
                 date: new Date().toISOString()
             }
             await trackingService.addTrackTCP(trackData)
@@ -171,7 +171,7 @@ describe('trackingService', () => {
                 latitude: lat,
                 longitude: lon,
                 speed: 10,
-                status: 'ON',
+                status: 1,
                 date: new Date().toISOString()
             }
             const result = await trackingService.addTrackTCP(trackData)
@@ -188,14 +188,14 @@ describe('trackingService', () => {
                 latitude: lat,
                 longitude: lon,
                 speed: 123.21,
-                status: 'OFF',
+                status: 0,
                 date: new Date().toISOString()
             }
             await trackingService.addTrackTCP(trackData)
             const saved = await Track.findOne({ serialNumber: '1234567890' })
             expect(saved).toBeDefined()
-            expect(saved.speed).toBe(123.21)
-            expect(saved.status).toBe('OFF')
+            expect(saved.speed).toBe(123.2)
+            expect(saved.status).toBe(0)
         })
 
         it('should succeed on correct track partial data', async () => {
@@ -209,7 +209,7 @@ describe('trackingService', () => {
             const saved = await Track.findOne({ serialNumber: '1234567890' })
             expect(saved).toBeDefined()
             expect(saved.speed).toBe(0)
-            expect(saved.status).toBe('ON')
+            expect(saved.status).toBe(1)
         })
 
         it('should silently discard (return null, no Track persisted) on unknown serial number', async () => {
@@ -218,7 +218,7 @@ describe('trackingService', () => {
                 latitude: lat,
                 longitude: lon,
                 speed: 123.21,
-                status: 'ON',
+                status: 1,
                 date: new Date().toISOString()
             }
             const result = await trackingService.addTrackTCP(trackData)
@@ -251,7 +251,7 @@ describe('trackingService', () => {
                 latitude: 123.456,
                 longitude: lon,
                 speed: 50,
-                status: 'ON',
+                status: 1,
                 date: new Date().toISOString()
             }
 
@@ -275,11 +275,11 @@ describe('trackingService', () => {
             _password = await argon2.hash(password)
             user = await User.create({
                 name, surname, email, password: _password,
-                trackers: [{ serialNumber: '9000000001', licensePlate: 'XX-1111' }]
+                trackers: [{ serialNumber: '9000000001', alias: 'XX-1111' }]
             })
             // Create some tracks in the standalone collection
-            await Track.create({ serialNumber: '9000000001', latitude: lat, longitude: lon, speed: 10, status: 'ON', date: new Date(Date.now() - 2000) })
-            await Track.create({ serialNumber: '9000000001', latitude: lat + 1, longitude: lon + 1, speed: 99, status: 'OFF', date: new Date() })
+            await Track.create({ serialNumber: '9000000001', latitude: lat, longitude: lon, speed: 10, status: 1, date: new Date(Date.now() - 2000) })
+            await Track.create({ serialNumber: '9000000001', latitude: lat + 1, longitude: lon + 1, speed: 99, status: 0, date: new Date() })
         })
 
         it('should return the most recent track for a tracker', async () => {
@@ -358,23 +358,23 @@ describe('trackingService', () => {
             user = await User.create({
                 name, surname, email, password: _password,
                 trackers: [
-                    { serialNumber: '9000000010', licensePlate: 'AA-0001' },
-                    { serialNumber: '9000000011', licensePlate: 'AA-0002' }
+                    { serialNumber: '9000000010', alias: 'AA-0001' },
+                    { serialNumber: '9000000011', alias: 'AA-0002' }
                 ]
             })
             _user = await User.create({ name, surname, email: '123@123.com', password: _password })
 
-            await Track.create({ serialNumber: '9000000010', latitude: lat, longitude: lon, speed: 50, status: 'ON', date: new Date(Date.now() - 1000) })
-            await Track.create({ serialNumber: '9000000010', latitude: lat, longitude: lon, speed: 60, status: 'ON', date: new Date() })
-            await Track.create({ serialNumber: '9000000011', latitude: lat, longitude: lon, speed: 80, status: 'OFF', date: new Date() })
+            await Track.create({ serialNumber: '9000000010', latitude: lat, longitude: lon, speed: 50, status: 1, date: new Date(Date.now() - 1000) })
+            await Track.create({ serialNumber: '9000000010', latitude: lat, longitude: lon, speed: 60, status: 1, date: new Date() })
+            await Track.create({ serialNumber: '9000000011', latitude: lat, longitude: lon, speed: 80, status: 0, date: new Date() })
         })
 
-        it('should return last track for each tracker enriched with licensePlate', async () => {
+        it('should return last track for each tracker enriched with alias', async () => {
             const resp = await trackingService.retrieveAllLastTracks(user.id)
             expect(resp.length).toBe(2)
-            // each result should have licensePlate
-            expect(resp[0].licensePlate).toBeDefined()
-            expect(resp[1].licensePlate).toBeDefined()
+            // each result should have alias
+            expect(resp[0].alias).toBeDefined()
+            expect(resp[1].alias).toBeDefined()
             // last track for first tracker should be speed 60
             const t1 = resp.find(r => r.serialNumber === '9000000010')
             expect(t1).toBeDefined()
@@ -424,7 +424,7 @@ describe('trackingService', () => {
             _password = await argon2.hash(password)
             user = await User.create({
                 name, surname, email, password: _password,
-                trackers: [{ serialNumber: '978878981234', licensePlate: '1234-ABC' }]
+                trackers: [{ serialNumber: '978878981234', alias: '1234-ABC' }]
             })
 
             // Create 60 tracks within a time window
@@ -437,7 +437,7 @@ describe('trackingService', () => {
                 latitude: Math.random() * 100,
                 longitude: Math.random() * 10,
                 speed: 100 + i,
-                status: 'ON',
+                status: 1,
                 date: new Date(base + i * 900)
             }))
             await Track.insertMany(trackDocs)

--- a/track-app/src/components/App.tsx
+++ b/track-app/src/components/App.tsx
@@ -68,6 +68,10 @@ function App() {
     meData?.me?.featureKeys?.includes('backoffice') &&
     meData?.me?.permissionKeys?.includes('users.update')
   )
+  const canCreateTrackers = Boolean(
+    meData?.me?.featureKeys?.includes('backoffice') &&
+    meData?.me?.permissionKeys?.includes('fleet.create')
+  )
   const canAccessBackoffice = Boolean(
     meData?.me?.featureKeys?.includes('backoffice') &&
     (meData?.me?.permissionKeys?.includes('companies.read') || meData?.me?.permissionKeys?.includes('users.read'))
@@ -156,6 +160,7 @@ function App() {
               canReadUsers={canReadUsers}
               canCreateUsers={canCreateUsers}
               canUpdateUsers={canUpdateUsers}
+              canCreateTrackers={canCreateTrackers}
             />
           )}
         />

--- a/track-app/src/components/Backoffice/index.tsx
+++ b/track-app/src/components/Backoffice/index.tsx
@@ -15,6 +15,7 @@ interface BackofficeProps {
   canReadUsers?: boolean
   canCreateUsers?: boolean
   canUpdateUsers?: boolean
+  canCreateTrackers?: boolean
 }
 
 type BackofficeTab = 'companies' | 'users'
@@ -22,7 +23,8 @@ type BackofficeTab = 'companies' | 'users'
 function Backoffice({
   canReadUsers = true,
   canCreateUsers = true,
-  canUpdateUsers = true
+  canUpdateUsers = true,
+  canCreateTrackers = true
 }: BackofficeProps) {
   const { t } = useTranslation()
   const labelClass = 'mb-2 block text-sm font-semibold'
@@ -31,7 +33,7 @@ function Backoffice({
   const checkboxClass = 'mr-4 inline-flex items-center gap-2 text-sm text-[var(--text-primary)]'
 
   const [usersPage, setUsersPage] = useState(1)
-  const { companies, users, usersTotalCount, loading, createCompany, createUser, updateCompany, updateUser } = useBackoffice(usersPage, 20, canReadUsers)
+  const { companies, users, usersTotalCount, loading, createCompany, createUser, createTracker, updateCompany, updateUser } = useBackoffice(usersPage, 20, canReadUsers)
   const canSeeUsersTab = canReadUsers || canCreateUsers || canUpdateUsers
   const [activeTab, setActiveTab] = useState<BackofficeTab>('companies')
   const [companyForm, setCompanyForm] = useState({
@@ -48,6 +50,11 @@ function Backoffice({
     role: 'admin',
     companyId: '',
     permissionKeys: permissionTemplateForRole('admin')
+  })
+  const [trackerForm, setTrackerForm] = useState({
+    serialNumber: '',
+    alias: '',
+    companyId: ''
   })
   const [selectedCompanyId, setSelectedCompanyId] = useState<string>('')
   const [selectedUserId, setSelectedUserId] = useState<string>('')
@@ -119,6 +126,20 @@ function Backoffice({
       role: 'admin',
       companyId: '',
       permissionKeys: permissionTemplateForRole('admin')
+    })
+  }
+
+  const onCreateTracker = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await createTracker({
+      serialNumber: trackerForm.serialNumber,
+      alias: trackerForm.alias || undefined,
+      companyId: trackerForm.companyId
+    })
+    setTrackerForm({
+      serialNumber: '',
+      alias: '',
+      companyId: ''
     })
   }
 
@@ -253,6 +274,49 @@ function Backoffice({
           <button className={primaryButtonClass} type="submit">{t('backoffice.createCompany')}</button>
         </form>
       </section>
+
+      {canCreateTrackers && (
+      <section className="pb-8 border-b" style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
+        <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.createTracker')}</h3>
+        <form onSubmit={onCreateTracker}>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div>
+              <label className={labelClass}>{t('trackers.serialNumber')}</label>
+              <input
+                className={inputClass}
+                value={trackerForm.serialNumber}
+                onChange={(e) => setTrackerForm(prev => ({ ...prev, serialNumber: e.target.value }))}
+                required
+              />
+            </div>
+            <div>
+              <label className={labelClass}>{t('ui.alias')}</label>
+              <input
+                className={inputClass}
+                value={trackerForm.alias}
+                onChange={(e) => setTrackerForm(prev => ({ ...prev, alias: e.target.value }))}
+                placeholder={t('ui.optional')}
+              />
+            </div>
+            <div className="md:col-span-2">
+              <label className={labelClass}>{t('backoffice.company')}</label>
+              <select
+                className={inputClass}
+                value={trackerForm.companyId}
+                onChange={(e) => setTrackerForm(prev => ({ ...prev, companyId: e.target.value }))}
+                required
+              >
+                <option value="">{t('backoffice.selectCompany')}</option>
+                {companyOptions.map((company) => (
+                  <option key={company.id} value={company.id}>{company.label}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <button className={primaryButtonClass} type="submit">{t('backoffice.createTracker')}</button>
+        </form>
+      </section>
+      )}
 
       <section className="pb-8 border-b" style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
         <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.companies')}</h3>

--- a/track-app/src/components/Home/index.tsx
+++ b/track-app/src/components/Home/index.tsx
@@ -15,8 +15,8 @@ function Home({ darkmode }: HomeProps) {
   const { t } = useTranslation()
   const { pois, trackers, lastTracks, livePositions, deletePOI, goToDetail } = useLiveTracks()
   const location = useLocation()
-  const licenseBySerial = useMemo(
-    () => new Map(trackers.map(tracker => [tracker.serialNumber, tracker.licensePlate || tracker.serialNumber])),
+  const aliasBySerial = useMemo(
+    () => new Map(trackers.map(tracker => [tracker.serialNumber, tracker.alias || tracker.serialNumber])),
     [trackers]
   )
 
@@ -139,11 +139,11 @@ function Home({ darkmode }: HomeProps) {
       const status = 'status' in truck ? truck.status : undefined
       const freshness = 'date' in truck ? telemetryFreshness(truck.date) : { label: 'STALE', color: '#f59e0b' }
       const sn = truck.serialNumber
-      const lp = truck.licensePlate || licenseBySerial.get(sn) || sn
-      const popupSignature = `${lp}|${status || ''}|${speed.toFixed(2)}|${freshness.label}`
+      const alias = truck.alias || aliasBySerial.get(sn) || sn
+      const popupSignature = `${alias}|${status || ''}|${speed.toFixed(2)}|${freshness.label}`
       const popupHtml = `
         <div class="tracker-popup">
-          <div class="tracker-popup__title">${lp}</div>
+          <div class="tracker-popup__title">${alias}</div>
           <div class="tracker-popup__meta">${t('home.sn')}: ${sn}</div>
           <div class="tracker-popup__row">
             <span>${t('home.speed')}</span>

--- a/track-app/src/components/TrackingDetail/DetailForm.tsx
+++ b/track-app/src/components/TrackingDetail/DetailForm.tsx
@@ -3,11 +3,11 @@ import { useTranslation } from 'react-i18next'
 
 interface DetailFormProps {
   onSubmitDetail: (dateFrom: string, timeFrom: string, dateTo: string, timeTo: string) => void
-  licensePlate?: string | null
+  alias?: string | null
   serialNumber?: string
 }
 
-function DetailForm({ onSubmitDetail, licensePlate, serialNumber }: DetailFormProps) {
+function DetailForm({ onSubmitDetail, alias, serialNumber }: DetailFormProps) {
   const { t } = useTranslation()
   const labelClass = 'mb-2 block text-sm font-semibold'
   const inputClass = 'glass-input-base w-full rounded-full border px-4 py-2 text-sm outline-none transition'
@@ -38,7 +38,7 @@ function DetailForm({ onSubmitDetail, licensePlate, serialNumber }: DetailFormPr
 
   return (
     <section className="tracking-detail__form">
-      <h2 className="tracking-detail__title">{licensePlate || t('detail.trackerNotLoaded')}</h2>
+      <h2 className="tracking-detail__title">{alias || t('detail.trackerNotLoaded')}</h2>
       <p className="tracking-detail__subtitle">
         {serialNumber}
       </p>

--- a/track-app/src/components/TrackingDetail/index.tsx
+++ b/track-app/src/components/TrackingDetail/index.tsx
@@ -160,7 +160,7 @@ function TrackingDetail({ darkmode, serialNumber }: TrackingDetailProps) {
     })
     const popupHtml = `
       <div class="tracker-popup">
-        <div class="tracker-popup__title">${tracker?.licensePlate || serialNumber}</div>
+        <div class="tracker-popup__title">${tracker?.alias || serialNumber}</div>
         <div class="tracker-popup__meta">${t('home.sn')}: ${serialNumber}</div>
         <div class="tracker-popup__row">
           <span>${t('home.speed')}</span>
@@ -531,7 +531,7 @@ function TrackingDetail({ darkmode, serialNumber }: TrackingDetailProps) {
         )}
         <DetailForm
           onSubmitDetail={handleSubmitDetail}
-          licensePlate={tracker?.licensePlate}
+          alias={tracker?.alias}
           serialNumber={tracker?.serialNumber}
         />
       </div>

--- a/track-app/src/components/Trackings/New.tsx
+++ b/track-app/src/components/Trackings/New.tsx
@@ -13,8 +13,8 @@ function TrackingsNew() {
     e.preventDefault()
     const form = e.currentTarget
     const serialNumber = (form.elements.namedItem('serialNumber') as HTMLInputElement).value
-    const licensePlate = (form.elements.namedItem('licensePlate') as HTMLInputElement).value
-    addTracker({ serialNumber, licensePlate: licensePlate || null })
+    const alias = (form.elements.namedItem('alias') as HTMLInputElement).value
+    addTracker({ serialNumber, alias: alias || null })
     form.reset()
   }
 
@@ -38,7 +38,7 @@ function TrackingsNew() {
           <input
             className={inputClass}
             type="text"
-            name="licensePlate"
+            name="alias"
             placeholder={t('ui.alias')}
           />
         </div>

--- a/track-app/src/components/Trackings/index.tsx
+++ b/track-app/src/components/Trackings/index.tsx
@@ -44,7 +44,7 @@ function Trackings() {
         />
       )
     },
-    { key: 'licensePlate', label: t('ui.alias') },
+    { key: 'alias', label: t('ui.alias') },
     { key: 'serialNumber', label: t('ui.serial') },
     {
       key: 'actions',
@@ -128,7 +128,7 @@ function Trackings() {
           <section className="px-4 py-3">
             {pendingDelete && (
               <p>
-                {t('trackers.deleteQuestion', { name: pendingDelete.licensePlate || pendingDelete.serialNumber })} 
+                {t('trackers.deleteQuestion', { name: pendingDelete.alias || pendingDelete.serialNumber })} 
               </p>
             )}
           </section>

--- a/track-app/src/generated/graphql.ts
+++ b/track-app/src/generated/graphql.ts
@@ -47,6 +47,12 @@ export type BackofficeCreateCompanyInput = {
   slug?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type BackofficeCreateTrackerInput = {
+  alias?: InputMaybe<Scalars['String']['input']>;
+  companyId: Scalars['ID']['input'];
+  serialNumber: Scalars['String']['input'];
+};
+
 export type BackofficeCreateUserInput = {
   companyId: Scalars['ID']['input'];
   email: Scalars['String']['input'];
@@ -112,6 +118,7 @@ export type Mutation = {
   addPOI: MutationResult;
   addTracker: MutationResult;
   backofficeCreateCompany: MutationResult;
+  backofficeCreateTracker: MutationResult;
   backofficeCreateUser: MutationResult;
   backofficeUpdateCompany: MutationResult;
   backofficeUpdateUser: MutationResult;
@@ -138,6 +145,11 @@ export type MutationAddTrackerArgs = {
 
 export type MutationBackofficeCreateCompanyArgs = {
   input: BackofficeCreateCompanyInput;
+};
+
+
+export type MutationBackofficeCreateTrackerArgs = {
+  input: BackofficeCreateTrackerInput;
 };
 
 
@@ -395,6 +407,13 @@ export type BackofficeCreateUserMutationVariables = Exact<{
 
 
 export type BackofficeCreateUserMutation = { __typename?: 'Mutation', backofficeCreateUser: { __typename?: 'MutationResult', success: boolean, message: string } };
+
+export type BackofficeCreateTrackerMutationVariables = Exact<{
+  input: BackofficeCreateTrackerInput;
+}>;
+
+
+export type BackofficeCreateTrackerMutation = { __typename?: 'Mutation', backofficeCreateTracker: { __typename?: 'MutationResult', success: boolean, message: string } };
 
 export type BackofficeUpdateUserMutationVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -719,6 +738,40 @@ export function useBackofficeCreateUserMutation(baseOptions?: Apollo.MutationHoo
 export type BackofficeCreateUserMutationHookResult = ReturnType<typeof useBackofficeCreateUserMutation>;
 export type BackofficeCreateUserMutationResult = Apollo.MutationResult<BackofficeCreateUserMutation>;
 export type BackofficeCreateUserMutationOptions = Apollo.BaseMutationOptions<BackofficeCreateUserMutation, BackofficeCreateUserMutationVariables>;
+export const BackofficeCreateTrackerDocument = gql`
+    mutation BackofficeCreateTracker($input: BackofficeCreateTrackerInput!) {
+  backofficeCreateTracker(input: $input) {
+    success
+    message
+  }
+}
+    `;
+export type BackofficeCreateTrackerMutationFn = Apollo.MutationFunction<BackofficeCreateTrackerMutation, BackofficeCreateTrackerMutationVariables>;
+
+/**
+ * __useBackofficeCreateTrackerMutation__
+ *
+ * To run a mutation, you first call `useBackofficeCreateTrackerMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useBackofficeCreateTrackerMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [backofficeCreateTrackerMutation, { data, loading, error }] = useBackofficeCreateTrackerMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useBackofficeCreateTrackerMutation(baseOptions?: Apollo.MutationHookOptions<BackofficeCreateTrackerMutation, BackofficeCreateTrackerMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<BackofficeCreateTrackerMutation, BackofficeCreateTrackerMutationVariables>(BackofficeCreateTrackerDocument, options);
+      }
+export type BackofficeCreateTrackerMutationHookResult = ReturnType<typeof useBackofficeCreateTrackerMutation>;
+export type BackofficeCreateTrackerMutationResult = Apollo.MutationResult<BackofficeCreateTrackerMutation>;
+export type BackofficeCreateTrackerMutationOptions = Apollo.BaseMutationOptions<BackofficeCreateTrackerMutation, BackofficeCreateTrackerMutationVariables>;
 export const BackofficeUpdateUserDocument = gql`
     mutation BackofficeUpdateUser($id: ID!, $input: BackofficeUpdateUserInput!) {
   backofficeUpdateUser(id: $id, input: $input) {

--- a/track-app/src/generated/graphql.ts
+++ b/track-app/src/generated/graphql.ts
@@ -31,7 +31,7 @@ export type AddPoiInput = {
 };
 
 export type AddTrackerInput = {
-  licensePlate?: InputMaybe<Scalars['String']['input']>;
+  alias?: InputMaybe<Scalars['String']['input']>;
   serialNumber: Scalars['String']['input'];
 };
 
@@ -98,9 +98,9 @@ export type Company = {
 
 export type LiveTrack = {
   __typename?: 'LiveTrack';
+  alias?: Maybe<Scalars['String']['output']>;
   date: Scalars['DateTime']['output'];
   latitude: Scalars['Float']['output'];
-  licensePlate?: Maybe<Scalars['String']['output']>;
   longitude: Scalars['Float']['output'];
   serialNumber: Scalars['String']['output'];
   speed: Scalars['Float']['output'];
@@ -239,7 +239,7 @@ export type Query = {
   pois: PagedPoIs;
   trackRange: Array<Track>;
   tracker: Tracker;
-  trackerByLP: Tracker;
+  trackerByAlias: Tracker;
   trackerBySN: Tracker;
   trackers: PagedTrackers;
 };
@@ -280,8 +280,8 @@ export type QueryTrackerArgs = {
 };
 
 
-export type QueryTrackerByLpArgs = {
-  licensePlate: Scalars['String']['input'];
+export type QueryTrackerByAliasArgs = {
+  alias: Scalars['String']['input'];
 };
 
 
@@ -321,8 +321,8 @@ export type Track = {
 
 export type Tracker = {
   __typename?: 'Tracker';
+  alias?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
-  licensePlate?: Maybe<Scalars['String']['output']>;
   serialNumber: Scalars['String']['output'];
 };
 
@@ -334,7 +334,7 @@ export type UpdatePoiInput = {
 };
 
 export type UpdateTrackerInput = {
-  licensePlate?: InputMaybe<Scalars['String']['input']>;
+  alias?: InputMaybe<Scalars['String']['input']>;
   serialNumber?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -410,14 +410,14 @@ export type GetTrackersQueryVariables = Exact<{
 }>;
 
 
-export type GetTrackersQuery = { __typename?: 'Query', trackers: { __typename?: 'PagedTrackers', totalCount: number, items: Array<{ __typename?: 'Tracker', id: string, serialNumber: string, licensePlate?: string | null }> } };
+export type GetTrackersQuery = { __typename?: 'Query', trackers: { __typename?: 'PagedTrackers', totalCount: number, items: Array<{ __typename?: 'Tracker', id: string, serialNumber: string, alias?: string | null }> } };
 
 export type TrackerBySnQueryVariables = Exact<{
   serialNumber: Scalars['String']['input'];
 }>;
 
 
-export type TrackerBySnQuery = { __typename?: 'Query', trackerBySN: { __typename?: 'Tracker', id: string, serialNumber: string, licensePlate?: string | null } };
+export type TrackerBySnQuery = { __typename?: 'Query', trackerBySN: { __typename?: 'Tracker', id: string, serialNumber: string, alias?: string | null } };
 
 export type AddTrackerMutationVariables = Exact<{
   input: AddTrackerInput;
@@ -498,7 +498,7 @@ export type DeletePoiMutation = { __typename?: 'Mutation', deletePOI: { __typena
 export type LastTracksQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type LastTracksQuery = { __typename?: 'Query', lastTracks: Array<{ __typename?: 'LiveTrack', serialNumber: string, latitude: number, longitude: number, speed: number, status: string, date: any, licensePlate?: string | null }> };
+export type LastTracksQuery = { __typename?: 'Query', lastTracks: Array<{ __typename?: 'LiveTrack', serialNumber: string, latitude: number, longitude: number, speed: number, status: string, date: any, alias?: string | null }> };
 
 export type TrackRangeQueryVariables = Exact<{
   trackerId: Scalars['ID']['input'];
@@ -512,7 +512,7 @@ export type TrackRangeQuery = { __typename?: 'Query', trackRange: Array<{ __type
 export type LiveTracksUpdatedSubscriptionVariables = Exact<{ [key: string]: never; }>;
 
 
-export type LiveTracksUpdatedSubscription = { __typename?: 'Subscription', liveTracksUpdated: Array<{ __typename?: 'LiveTrack', serialNumber: string, latitude: number, longitude: number, speed: number, status: string, date: any, licensePlate?: string | null }> };
+export type LiveTracksUpdatedSubscription = { __typename?: 'Subscription', liveTracksUpdated: Array<{ __typename?: 'LiveTrack', serialNumber: string, latitude: number, longitude: number, speed: number, status: string, date: any, alias?: string | null }> };
 
 
 export const BackofficeCompaniesDocument = gql`
@@ -761,7 +761,7 @@ export const GetTrackersDocument = gql`
     items {
       id
       serialNumber
-      licensePlate
+      alias
     }
   }
 }
@@ -808,7 +808,7 @@ export const TrackerBySnDocument = gql`
   trackerBySN(serialNumber: $serialNumber) {
     id
     serialNumber
-    licensePlate
+    alias
   }
 }
     `;
@@ -1264,7 +1264,7 @@ export const LastTracksDocument = gql`
     speed
     status
     date
-    licensePlate
+    alias
   }
 }
     `;
@@ -1363,7 +1363,7 @@ export const LiveTracksUpdatedDocument = gql`
     speed
     status
     date
-    licensePlate
+    alias
   }
 }
     `;

--- a/track-app/src/graphql/backoffice.gql
+++ b/track-app/src/graphql/backoffice.gql
@@ -48,6 +48,13 @@ mutation BackofficeCreateUser($input: BackofficeCreateUserInput!) {
   }
 }
 
+mutation BackofficeCreateTracker($input: BackofficeCreateTrackerInput!) {
+  backofficeCreateTracker(input: $input) {
+    success
+    message
+  }
+}
+
 mutation BackofficeUpdateUser($id: ID!, $input: BackofficeUpdateUserInput!) {
   backofficeUpdateUser(id: $id, input: $input) {
     success

--- a/track-app/src/graphql/fleet.gql
+++ b/track-app/src/graphql/fleet.gql
@@ -1,11 +1,11 @@
 query GetTrackers($offset: Int = 0, $limit: Int = 20) {
   trackers(offset: $offset, limit: $limit) {
     totalCount
-    items { id serialNumber licensePlate }
+    items { id serialNumber alias }
   }
 }
 query TrackerBySN($serialNumber: String!) {
-  trackerBySN(serialNumber: $serialNumber) { id serialNumber licensePlate }
+  trackerBySN(serialNumber: $serialNumber) { id serialNumber alias }
 }
 mutation AddTracker($input: AddTrackerInput!) {
   addTracker(input: $input) { success message }

--- a/track-app/src/graphql/tracking.gql
+++ b/track-app/src/graphql/tracking.gql
@@ -1,5 +1,5 @@
 query LastTracks {
-  lastTracks { serialNumber latitude longitude speed status date licensePlate }
+  lastTracks { serialNumber latitude longitude speed status date alias }
 }
 query TrackRange($trackerId: ID!, $start: DateTime!, $end: DateTime!) {
   trackRange(trackerId: $trackerId, start: $start, end: $end) {
@@ -7,5 +7,5 @@ query TrackRange($trackerId: ID!, $start: DateTime!, $end: DateTime!) {
   }
 }
 subscription LiveTracksUpdated {
-  liveTracksUpdated { serialNumber latitude longitude speed status date licensePlate }
+  liveTracksUpdated { serialNumber latitude longitude speed status date alias }
 }

--- a/track-app/src/hooks/useBackoffice.ts
+++ b/track-app/src/hooks/useBackoffice.ts
@@ -5,6 +5,7 @@ import {
     BackofficeUsersDocument,
     useBackofficeCompaniesQuery,
     useBackofficeCreateCompanyMutation,
+    useBackofficeCreateTrackerMutation,
     useBackofficeCreateUserMutation,
     useBackofficeUpdateCompanyMutation,
     useBackofficeUpdateUserMutation,
@@ -58,6 +59,11 @@ export function useBackoffice(usersPage = 1, pageSize = 20, enableUsersQuery = t
     const [createUserMutation] = useBackofficeCreateUserMutation({
         onError: (err) => toast.error(err.message),
         refetchQueries: [{ query: BackofficeUsersDocument }]
+    })
+
+    const [createTrackerMutation] = useBackofficeCreateTrackerMutation({
+        onError: (err) => toast.error(err.message),
+        refetchQueries: [{ query: BackofficeCompaniesDocument }]
     })
 
     const [updateUserMutation] = useBackofficeUpdateUserMutation({
@@ -114,6 +120,15 @@ export function useBackoffice(usersPage = 1, pageSize = 20, enableUsersQuery = t
         if (res.data?.backofficeCreateUser.success) toast.success(res.data.backofficeCreateUser.message)
     }
 
+    const createTracker = async (input: {
+        serialNumber: string
+        alias?: string
+        companyId: string
+    }) => {
+        const res = await createTrackerMutation({ variables: { input } })
+        if (res.data?.backofficeCreateTracker.success) toast.success(res.data.backofficeCreateTracker.message)
+    }
+
     const updateUser = async (id: string, input: {
         name?: string
         surname?: string
@@ -135,6 +150,7 @@ export function useBackoffice(usersPage = 1, pageSize = 20, enableUsersQuery = t
         createCompany,
         updateCompany,
         createUser,
+        createTracker,
         updateUser
     }
 }

--- a/track-app/src/locales/ca/common.json
+++ b/track-app/src/locales/ca/common.json
@@ -159,6 +159,7 @@
     "companies": "Companyies",
     "editCompany": "Editar companyia",
     "createUser": "Crear usuari",
+    "createTracker": "Crear tracker",
     "editUser": "Editar usuari",
     "users": "Usuaris",
     "active": "Actiu",

--- a/track-app/src/locales/en/common.json
+++ b/track-app/src/locales/en/common.json
@@ -96,6 +96,7 @@
     "newUserAction": "+ New User",
     "empty": "No users found in this company.",
     "createUser": "Create User",
+    "createTracker": "Create Tracker",
     "companyNotFound": "Company not found for current user"
   },
   "places": {

--- a/track-app/src/locales/es/common.json
+++ b/track-app/src/locales/es/common.json
@@ -159,6 +159,7 @@
     "companies": "Compañías",
     "editCompany": "Editar compañía",
     "createUser": "Crear usuario",
+    "createTracker": "Crear tracker",
     "editUser": "Editar usuario",
     "users": "Usuarios",
     "active": "Activo",

--- a/track-data/__tests__/models.test.js
+++ b/track-data/__tests__/models.test.js
@@ -9,7 +9,7 @@ describe('Track model (standalone collection)', () => {
             latitude: 41.390205,
             longitude: 2.154007,
             speed: 90,
-            status: 'ON'
+            status: 1
         })
         const saved = await track.save()
         expect(saved._id).toBeDefined()
@@ -17,7 +17,7 @@ describe('Track model (standalone collection)', () => {
         expect(saved.latitude).toBe(41.390205)
         expect(saved.longitude).toBe(2.154007)
         expect(saved.speed).toBe(90)
-        expect(saved.status).toBe('ON')
+        expect(saved.status).toBe(1)
         expect(saved.date).toBeInstanceOf(Date)
     })
 
@@ -88,12 +88,12 @@ describe('User model', () => {
             surname: 'User',
             email: 'tracker-test@example.com',
             password: 'hashed',
-            trackers: [{ serialNumber: '9900220022', licensePlate: 'ABC-1234' }]
+            trackers: [{ serialNumber: '9900220022', alias: 'ABC-1234' }]
         })
         const saved = await user.save()
         expect(saved.trackers).toHaveLength(1)
         expect(saved.trackers[0].serialNumber).toBe('9900220022')
-        expect(saved.trackers[0].licensePlate).toBe('ABC-1234')
+        expect(saved.trackers[0].alias).toBe('ABC-1234')
         expect(saved.trackers[0].tracks).toBeUndefined()
     })
 })

--- a/track-data/models/schemas/index.js
+++ b/track-data/models/schemas/index.js
@@ -15,14 +15,14 @@ const TrackSchema = new Schema({
     latitude:     { type: Number, required: true },
     longitude:    { type: Number, required: true },
     speed:        { type: Number, required: true },
-    status:       { type: String, default: 'ON' },
+    status:       { type: Number, enum: [0, 1], default: 1 },
     date:         { type: Date, default: Date.now }
 })
-TrackSchema.index({ serialNumber: 1, date: -1 })
+TrackSchema.index({ serialNumber: 1, date: 1 })
 
 const tracker = new Schema({
     serialNumber: { type: String, required: true, index: true },
-    licensePlate: { type: String }
+    alias: { type: String }
 })
 
 const company = new Schema({
@@ -36,7 +36,7 @@ const company = new Schema({
 const companyTracker = new Schema({
     companyId: { type: Schema.Types.ObjectId, ref: 'Company', required: true, index: true },
     serialNumber: { type: String, required: true, unique: true, index: true },
-    licensePlate: { type: String, required: true, index: true }
+    alias: { type: String, required: true, index: true }
 }, { timestamps: true })
 
 const poi = new Schema({

--- a/tracker-simulator/randomGPS.js
+++ b/tracker-simulator/randomGPS.js
@@ -108,7 +108,7 @@ const ROUTES = TRUCK_ASSIGNMENTS.map(truck => {
 
     return {
         serialNumber: truck.serialNumber,
-        licensePlate: truck.licensePlate,
+        alias: truck.alias,
         routeName: route.name,
         startsInbound: truck.startsInbound,
         restStopIndexes: buildRestStopIndexes(route.waypoints.length),

--- a/tracker-simulator/setup.js
+++ b/tracker-simulator/setup.js
@@ -128,7 +128,7 @@ async function main() {
 
     // ── 4. Assign each simulator tracker ─────────────────────────────────────
     for (const tracker of SIM_TRACKERS) {
-        const { serialNumber, licensePlate } = tracker
+        const { serialNumber, alias } = tracker
 
         if (!DEMO_SERIALS.has(serialNumber)) {
             log('⛔', `Refusing to assign non-demo serial ${serialNumber}`)
@@ -148,9 +148,9 @@ async function main() {
             await api('/trackers/add', {
                 method: 'POST',
                 token,
-                data: { serialNumber, licensePlate }
+                data: { serialNumber, alias }
             })
-            log('✅', `SN ${serialNumber} (${licensePlate}) added to livedemo`)
+            log('✅', `SN ${serialNumber} (${alias}) added to livedemo`)
         } catch (err) {
             if (err.status === 409) {
                 log('⚠️ ', `SN ${serialNumber} is already registered to another account — skipped`)
@@ -170,7 +170,7 @@ async function main() {
 
     log('🏁', `Setup complete. livedemo has ${finalTrackers.length} tracker(s):`)
     finalTrackers.forEach(t => {
-        log('   🚚', `SN: ${t.serialNumber}  LP: ${t.licensePlate}`)
+        log('   🚚', `SN: ${t.serialNumber}  Alias: ${t.alias}`)
     })
 }
 

--- a/tracker-simulator/simulator.constants.js
+++ b/tracker-simulator/simulator.constants.js
@@ -9,8 +9,8 @@ function buildSimulatorTrackers(total = TOTAL_TRUCKS) {
     return Array.from({ length: total }, (_, index) => {
         const number = index + 1
         const serialNumber = String(SERIAL_BASE + number)
-        const licensePlate = `SIM-${String(number).padStart(4, '0')}`
-        return { serialNumber, licensePlate }
+        const alias = `SIM-${String(number).padStart(4, '0')}`
+        return { serialNumber, alias }
     })
 }
 


### PR DESCRIPTION
## Resumen\n- Unifica contrato de trackers a `alias` (elimina uso de `licensePlate` en API/GraphQL/frontend/simulador)\n- Añade y aplica migraciones de datos/índices para alias y naming de migraciones con patrón `YYYYMMDDHHmmss-name`\n- Migra `tracks` a time-series y optimiza almacenamiento Mongo (compresión zstd + reducción de índices redundantes)\n- Ajusta job de limpieza demo: ejecución diaria a las 00:00 y borrado completo de tracks demo\n- Compacta telemetría en tracks: `status` guardado como 0/1, lat/lon redondeadas a 5 decimales y speed a 1 decimal (API sigue exponiendo ON/OFF)\n- Añade utilidades de diagnóstico de footprint de DB\n\n## Migraciones incluidas\n- `20260410000000-backfill-user-language`\n- `20260416000000-rename-licenseplate-to-alias`\n- `20260416123000-migrate-tracks-to-timeseries`\n- `20260416130000-drop-redundant-tracks-desc-index`\n- `20260416133000-pack-tracks-telemetry-fields`\n- `20260416134000-fix-trackers-alias-indexes`\n\n## Validación\n- `track-api`: `npm test` (171/171)\n- `track-data`: `npm test` (10/10)\n