### PR TITLE
test: reforzar specs críticos y fix build Docker de track-app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1001,12 +1001,318 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-arm64": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
       "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
       ],
       "dev": true,
       "license": "MIT",
@@ -1035,6 +1341,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openharmony-arm64": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
@@ -1047,6 +1370,74 @@
       "optional": true,
       "os": [
         "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -5778,6 +6169,48 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escalade": {
@@ -10781,439 +11214,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
-      }
-    },
     "node_modules/vitest": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
@@ -11743,6 +11743,7 @@
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^6.0.1",
+        "esbuild": "^0.27.7",
         "jsdom": "^29.0.2",
         "postcss": "^8.4.49",
         "tailwindcss": "^4.1.14",

--- a/track-api/src/fleet/fleet.service.spec.js
+++ b/track-api/src/fleet/fleet.service.spec.js
@@ -3,6 +3,22 @@ const { errors: { LogicError, RequirementError, InputError } } = require('track-
 const argon2 = require('argon2')
 const service = require('./fleet.service')
 
+async function expectServiceError(run, ErrorType, message, matcher = 'toBe') {
+    let caught
+    try {
+        await run()
+    } catch (error) {
+        caught = error
+    }
+
+    expect(caught).toBeInstanceOf(ErrorType)
+    if (matcher === 'toContain') {
+        expect(caught.message).toContain(message)
+        return
+    }
+    expect(caught.message).toBe(message)
+}
+
 describe('fleetService', () => {
     let name, surname, email, password
 
@@ -42,72 +58,43 @@ describe('fleetService', () => {
 
         it('should fail on incorrect id user', async () => {
             const wrongId = '5cb9998f2e59ee0009eac02c'
-            try {
-                await service.addTracker(wrongId, { serialNumber: '1234567890' })
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`user with id ${wrongId} doesn't exists`)
-            }
+            await expectServiceError(() => service.addTracker(wrongId, { serialNumber: '1234567890' }), LogicError, `user with id ${wrongId} doesn't exists`)
         })
 
         it('should fail on undefined id user', async () => {
-            try {
-                await service.addTracker(undefined, { serialNumber: '1234567890' })
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`id is not optional`)
-            }
+            await expectServiceError(() => service.addTracker(undefined, { serialNumber: '1234567890' }), RequirementError, `id is not optional`)
         })
 
         it('should fail on null id user', async () => {
-            try {
-                await service.addTracker(null, { serialNumber: '1234567890' })
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`id is not optional`)
-            }
+            await expectServiceError(() => service.addTracker(null, { serialNumber: '1234567890' }), RequirementError, `id is not optional`)
         })
 
         it('should fail on undefined data tracker', async () => {
-            try {
-                await service.addTracker(user.id, undefined)
-            } catch (error) {
-                expect(error).toBeInstanceOf(InputError)
-                expect(error.message).toBe('incorrect tracker info')
-            }
+            await expectServiceError(() => service.addTracker(user.id, undefined), InputError, 'incorrect tracker info')
         })
 
         it('should fail on null data tracker', async () => {
-            try {
-                await service.addTracker(user.id, null)
-            } catch (error) {
-                expect(error).toBeInstanceOf(InputError)
-                expect(error.message).toBe('incorrect tracker info')
-            }
+            await expectServiceError(() => service.addTracker(user.id, null), InputError, 'incorrect tracker info')
         })
 
         it('should fail on add existing tracker serial number', async () => {
             const _serialNumber = '123123123'
-            try {
-                await service.addTracker(user.id, { serialNumber: _serialNumber })
-                await service.addTracker(user.id, { serialNumber: _serialNumber })
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`Serial Number ${_serialNumber} already registered`)
-            }
+            await service.addTracker(user.id, { serialNumber: _serialNumber })
+            await expectServiceError(() => 
+                service.addTracker(user.id, { serialNumber: _serialNumber }), LogicError,
+                `Serial Number ${_serialNumber} already registered`
+            )
         })
 
         it('should fail on add existing tracker license plate', async () => {
             const _serialNumber = '1234500000'
             const _alias = '1234-SKY'
             const __serialNumber = '1231456456'
-            try {
-                await service.addTracker(user.id, { serialNumber: _serialNumber, alias: _alias })
-                await service.addTracker(user.id, { serialNumber: __serialNumber, alias: _alias })
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`Alias ${_alias} already registered`)
-            }
+            await service.addTracker(user.id, { serialNumber: _serialNumber, alias: _alias })
+            await expectServiceError(() => 
+                service.addTracker(user.id, { serialNumber: __serialNumber, alias: _alias }), LogicError,
+                `Alias ${_alias} already registered`
+            )
         })
     })
 
@@ -129,12 +116,7 @@ describe('fleetService', () => {
 
         it('should fail on incorrect user id', async () => {
             const wrongId = '5cb9998f2e59ee0009eac02c'
-            try {
-                await service.retrieveAllTrackers(wrongId)
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`user with id ${wrongId} doesn't exists`)
-            }
+            await expectServiceError(() => service.retrieveAllTrackers(wrongId), LogicError, `user with id ${wrongId} doesn't exists`)
         })
 
         it('should return empty array for user without Trackers', async () => {
@@ -163,31 +145,16 @@ describe('fleetService', () => {
 
         it('should fail on incorrect user id', async () => {
             const wrongId = '5cb9998f2e59ee0009eac02c'
-            try {
-                await service.retrieveTracker(wrongId, user.trackers[0].id)
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`user with id ${wrongId} doesn't exists`)
-            }
+            await expectServiceError(() => service.retrieveTracker(wrongId, user.trackers[0].id), LogicError, `user with id ${wrongId} doesn't exists`)
         })
 
         it('should fail on user with wrong Tracker id', async () => {
             const trackerId = '1234132412'
-            try {
-                await service.retrieveTracker(user.id, trackerId)
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`Tracker with id ${trackerId} doesn't exists`)
-            }
+            await expectServiceError(() => service.retrieveTracker(user.id, trackerId), LogicError, `Tracker with id ${trackerId} doesn't exists`)
         })
 
         it('should fail on undefined Tracker id', async () => {
-            try {
-                await service.retrieveTracker(user.id, undefined)
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`trackerID is not optional`)
-            }
+            await expectServiceError(() => service.retrieveTracker(user.id, undefined), RequirementError, `trackerID is not optional`)
         })
     })
 
@@ -211,31 +178,16 @@ describe('fleetService', () => {
 
         it('should fail on incorrect user id', async () => {
             const wrongId = '5cb9998f2e59ee0009eac02c'
-            try {
-                await service.retrieveTrackerBySN(wrongId, '1234567890')
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`user with id ${wrongId} doesn't exists`)
-            }
+            await expectServiceError(() => service.retrieveTrackerBySN(wrongId, '1234567890'), LogicError, `user with id ${wrongId} doesn't exists`)
         })
 
         it('should fail on user with wrong Tracker SN', async () => {
             const trackerSN = 'FAKE_FAKE'
-            try {
-                await service.retrieveTrackerBySN(user.id, trackerSN)
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`Tracker with SN ${trackerSN} doesn't exists`)
-            }
+            await expectServiceError(() => service.retrieveTrackerBySN(user.id, trackerSN), LogicError, `Tracker with SN ${trackerSN} doesn't exists`)
         })
 
         it('should fail on undefined Serial Number', async () => {
-            try {
-                await service.retrieveTrackerBySN(user.id, undefined)
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`serialNumber is not optional`)
-            }
+            await expectServiceError(() => service.retrieveTrackerBySN(user.id, undefined), RequirementError, `serialNumber is not optional`)
         })
     })
 
@@ -259,31 +211,16 @@ describe('fleetService', () => {
 
         it('should fail on incorrect user id', async () => {
             const wrongId = '5cb9998f2e59ee0009eac02c'
-            try {
-                await service.retrieveTrackerByAlias(wrongId, '1234-ABC')
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`user with id ${wrongId} doesn't exists`)
-            }
+            await expectServiceError(() => service.retrieveTrackerByAlias(wrongId, '1234-ABC'), LogicError, `user with id ${wrongId} doesn't exists`)
         })
 
         it('should fail on user with wrong Tracker alias', async () => {
             const trackerLicense = 'FAKE_FAKE'
-            try {
-                await service.retrieveTrackerByAlias(user.id, trackerLicense)
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`Tracker with alias ${trackerLicense} doesn't exists`)
-            }
+            await expectServiceError(() => service.retrieveTrackerByAlias(user.id, trackerLicense), LogicError, `Tracker with alias ${trackerLicense} doesn't exists`)
         })
 
         it('should fail on undefined alias', async () => {
-            try {
-                await service.retrieveTrackerByAlias(user.id, undefined)
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`alias is not optional`)
-            }
+            await expectServiceError(() => service.retrieveTrackerByAlias(user.id, undefined), RequirementError, `alias is not optional`)
         })
     })
 
@@ -325,40 +262,20 @@ describe('fleetService', () => {
 
         it('should fail on incorrect user id', async () => {
             const wrongId = '5cb9998f2e59ee0009eac02c'
-            try {
-                await service.updateTracker(wrongId, user.trackers[0].id, { serialNumber: 'X' })
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`user with id ${wrongId} doesn't exists`)
-            }
+            await expectServiceError(() => service.updateTracker(wrongId, user.trackers[0].id, { serialNumber: 'X' }), LogicError, `user with id ${wrongId} doesn't exists`)
         })
 
         it('should fail on user with wrong Tracker id', async () => {
             const trackerId = '1234132412'
-            try {
-                await service.updateTracker(user.id, trackerId, { serialNumber: 'X' })
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`Tracker with id ${trackerId} doesn't exists`)
-            }
+            await expectServiceError(() => service.updateTracker(user.id, trackerId, { serialNumber: 'X' }), LogicError, `Tracker with id ${trackerId} doesn't exists`)
         })
 
         it('should fail on undefined tracker id', async () => {
-            try {
-                await service.updateTracker(user.id, undefined, { serialNumber: 'X' })
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`trackerID is not optional`)
-            }
+            await expectServiceError(() => service.updateTracker(user.id, undefined, { serialNumber: 'X' }), RequirementError, `trackerID is not optional`)
         })
 
         it('should fail on undefined trackerData', async () => {
-            try {
-                await service.updateTracker(user.id, user.trackers[0].id, undefined)
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`trackerData is not optional`)
-            }
+            await expectServiceError(() => service.updateTracker(user.id, user.trackers[0].id, undefined), RequirementError, `trackerData is not optional`)
         })
     })
 
@@ -383,31 +300,16 @@ describe('fleetService', () => {
 
         it('should fail on incorrect user id', async () => {
             const wrongId = '5cb9998f2e59ee0009eac02c'
-            try {
-                await service.deleteTracker(wrongId, user.trackers[0].id)
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`user with id ${wrongId} doesn't exists`)
-            }
+            await expectServiceError(() => service.deleteTracker(wrongId, user.trackers[0].id), LogicError, `user with id ${wrongId} doesn't exists`)
         })
 
         it('should fail on user with wrong tracker id', async () => {
             const trackerId = '1234132412'
-            try {
-                await service.deleteTracker(user.id, trackerId)
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`Tracker with id ${trackerId} doesn't exists`)
-            }
+            await expectServiceError(() => service.deleteTracker(user.id, trackerId), LogicError, `Tracker with id ${trackerId} doesn't exists`)
         })
 
         it('should fail on undefined tracker id', async () => {
-            try {
-                await service.deleteTracker(user.id, undefined)
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`trackerID is not optional`)
-            }
+            await expectServiceError(() => service.deleteTracker(user.id, undefined), RequirementError, `trackerID is not optional`)
         })
     })
 })

--- a/track-api/src/poi/poi.service.spec.js
+++ b/track-api/src/poi/poi.service.spec.js
@@ -3,6 +3,22 @@ const { errors: { LogicError, RequirementError, InputError } } = require('track-
 const argon2 = require('argon2')
 const service = require('./poi.service')
 
+async function expectServiceError(run, ErrorType, message, matcher = 'toBe') {
+    let caught
+    try {
+        await run()
+    } catch (error) {
+        caught = error
+    }
+
+    expect(caught).toBeInstanceOf(ErrorType)
+    if (matcher === 'toContain') {
+        expect(caught.message).toContain(message)
+        return
+    }
+    expect(caught.message).toBe(message)
+}
+
 describe('poiService', () => {
     let name, surname, email, password
 
@@ -71,84 +87,39 @@ describe('poiService', () => {
         it('should fail on incorrect id user', async () => {
             const wrongId = '5cb9998f2e59ee0009eac02c'
             const poiData = { title: 'My Fav', color: '#ff0000', latitude: 10, longitude: 2 }
-            try {
-                await service.addPOI(wrongId, poiData)
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`user with id ${wrongId} doesn't exists`)
-            }
+            await expectServiceError(() => service.addPOI(wrongId, poiData), LogicError, `user with id ${wrongId} doesn't exists`)
         })
 
         it('should fail on undefined id user', async () => {
-            try {
-                await service.addPOI(undefined, { title: 'X', color: '#fff', latitude: 1, longitude: 2 })
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`id is not optional`)
-            }
+            await expectServiceError(() => service.addPOI(undefined, { title: 'X', color: '#fff', latitude: 1, longitude: 2 }), RequirementError, `id is not optional`)
         })
 
         it('should fail on null id user', async () => {
-            try {
-                await service.addPOI(null, { title: 'X', color: '#fff', latitude: 1, longitude: 2 })
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`id is not optional`)
-            }
+            await expectServiceError(() => service.addPOI(null, { title: 'X', color: '#fff', latitude: 1, longitude: 2 }), RequirementError, `id is not optional`)
         })
 
         it('should fail on undefined data poi', async () => {
-            try {
-                await service.addPOI(user.id, undefined)
-            } catch (error) {
-                expect(error).toBeInstanceOf(InputError)
-                expect(error.message).toBe('incorrect poi info')
-            }
+            await expectServiceError(() => service.addPOI(user.id, undefined), InputError, 'incorrect poi info')
         })
 
         it('should fail on null data poi', async () => {
-            try {
-                await service.addPOI(user.id, null)
-            } catch (error) {
-                expect(error).toBeInstanceOf(InputError)
-                expect(error.message).toBe('incorrect poi info')
-            }
+            await expectServiceError(() => service.addPOI(user.id, null), InputError, 'incorrect poi info')
         })
 
         it('should fail on null data latitude', async () => {
-            try {
-                await service.addPOI(user.id, { title: 'X', color: '#fff', latitude: null, longitude: 2 })
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`latitude is not optional`)
-            }
+            await expectServiceError(() => service.addPOI(user.id, { title: 'X', color: '#fff', latitude: null, longitude: 2 }), RequirementError, `latitude is not optional`)
         })
 
         it('should fail on undefined data latitude', async () => {
-            try {
-                await service.addPOI(user.id, { title: 'X', color: '#fff', latitude: undefined, longitude: 2 })
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`latitude is not optional`)
-            }
+            await expectServiceError(() => service.addPOI(user.id, { title: 'X', color: '#fff', latitude: undefined, longitude: 2 }), RequirementError, `latitude is not optional`)
         })
 
         it('should fail on null data longitude', async () => {
-            try {
-                await service.addPOI(user.id, { title: 'X', color: '#fff', latitude: 1, longitude: null })
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`longitude is not optional`)
-            }
+            await expectServiceError(() => service.addPOI(user.id, { title: 'X', color: '#fff', latitude: 1, longitude: null }), RequirementError, `longitude is not optional`)
         })
 
         it('should fail on undefined data longitude', async () => {
-            try {
-                await service.addPOI(user.id, { title: 'X', color: '#fff', latitude: 1, longitude: undefined })
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`longitude is not optional`)
-            }
+            await expectServiceError(() => service.addPOI(user.id, { title: 'X', color: '#fff', latitude: 1, longitude: undefined }), RequirementError, `longitude is not optional`)
         })
     })
 
@@ -170,12 +141,7 @@ describe('poiService', () => {
 
         it('should fail on incorrect user id', async () => {
             const wrongId = '5cb9998f2e59ee0009eac02c'
-            try {
-                await service.retrieveAllPOI(wrongId)
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`user with id ${wrongId} doesn't exists`)
-            }
+            await expectServiceError(() => service.retrieveAllPOI(wrongId), LogicError, `user with id ${wrongId} doesn't exists`)
         })
 
         it('should return empty array for user without POIs', async () => {
@@ -206,31 +172,16 @@ describe('poiService', () => {
 
         it('should fail on incorrect user id', async () => {
             const wrongId = '5cb9998f2e59ee0009eac02c'
-            try {
-                await service.retrieveOnePOI(wrongId, user.pois[0].id)
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`user with id ${wrongId} doesn't exists`)
-            }
+            await expectServiceError(() => service.retrieveOnePOI(wrongId, user.pois[0].id), LogicError, `user with id ${wrongId} doesn't exists`)
         })
 
         it('should fail on user with wrong POI id', async () => {
             const poiId = '1234132412'
-            try {
-                await service.retrieveOnePOI(user.id, poiId)
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`POI with id ${poiId} doesn't exists`)
-            }
+            await expectServiceError(() => service.retrieveOnePOI(user.id, poiId), LogicError, `POI with id ${poiId} doesn't exists`)
         })
 
         it('should fail on undefined POI id', async () => {
-            try {
-                await service.retrieveOnePOI(user.id, undefined)
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`poiID is not optional`)
-            }
+            await expectServiceError(() => service.retrieveOnePOI(user.id, undefined), RequirementError, `poiID is not optional`)
         })
     })
 
@@ -265,40 +216,20 @@ describe('poiService', () => {
 
         it('should fail on incorrect user id', async () => {
             const wrongId = '5cb9998f2e59ee0009eac02c'
-            try {
-                await service.updatePOI(wrongId, user.pois[0].id, poiData)
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`user with id ${wrongId} doesn't exists`)
-            }
+            await expectServiceError(() => service.updatePOI(wrongId, user.pois[0].id, poiData), LogicError, `user with id ${wrongId} doesn't exists`)
         })
 
         it('should fail on user with wrong POI id', async () => {
             const poiId = '1234132412'
-            try {
-                await service.updatePOI(user.id, poiId, poiData)
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`POI with id ${poiId} doesn't exists`)
-            }
+            await expectServiceError(() => service.updatePOI(user.id, poiId, poiData), LogicError, `POI with id ${poiId} doesn't exists`)
         })
 
         it('should fail on undefined POI id', async () => {
-            try {
-                await service.updatePOI(user.id, undefined, poiData)
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`poiID is not optional`)
-            }
+            await expectServiceError(() => service.updatePOI(user.id, undefined, poiData), RequirementError, `poiID is not optional`)
         })
 
         it('should fail on undefined poiData', async () => {
-            try {
-                await service.updatePOI(user.id, user.pois[0].id, undefined)
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`poiData is not optional`)
-            }
+            await expectServiceError(() => service.updatePOI(user.id, user.pois[0].id, undefined), RequirementError, `poiData is not optional`)
         })
     })
 
@@ -325,31 +256,16 @@ describe('poiService', () => {
 
         it('should fail on incorrect user id', async () => {
             const wrongId = '5cb9998f2e59ee0009eac02c'
-            try {
-                await service.deletePOI(wrongId, user.pois[0].id)
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`user with id ${wrongId} doesn't exists`)
-            }
+            await expectServiceError(() => service.deletePOI(wrongId, user.pois[0].id), LogicError, `user with id ${wrongId} doesn't exists`)
         })
 
         it('should fail on user with wrong POI id', async () => {
             const poiId = '1234132412'
-            try {
-                await service.deletePOI(user.id, poiId)
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`POI with id ${poiId} doesn't exists`)
-            }
+            await expectServiceError(() => service.deletePOI(user.id, poiId), LogicError, `POI with id ${poiId} doesn't exists`)
         })
 
         it('should fail on undefined POI id', async () => {
-            try {
-                await service.deletePOI(user.id, undefined)
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`poiID is not optional`)
-            }
+            await expectServiceError(() => service.deletePOI(user.id, undefined), RequirementError, `poiID is not optional`)
         })
     })
 })

--- a/track-api/src/shared/access-control.spec.js
+++ b/track-api/src/shared/access-control.spec.js
@@ -5,8 +5,11 @@ const {
     encodeFeatureKeys,
     decodeFeatureKeys,
     effectivePermissionKeysForUser,
-    effectiveFeatureKeysForCompany
+    effectiveFeatureKeysForCompany,
+    hasPermission,
+    isFeatureEnabled
 } = require('./access-control')
+const { errors: { InputError } } = require('track-utils')
 
 describe('access-control', () => {
     it('encodes and decodes permission keys', () => {
@@ -39,5 +42,40 @@ describe('access-control', () => {
         expect(set.has('tracking')).toBeTruthy()
         expect(set.has('fleet')).toBeTruthy()
         expect(set.has('poi')).toBeTruthy()
+    })
+
+    it('returns empty set when version does not match ACCESS_VERSION', () => {
+        const packed = encodePermissionKeys(['fleet.read'])
+        const decoded = decodePermissionKeys(packed, ACCESS_VERSION + 1)
+        expect(decoded.size).toBe(0)
+    })
+
+    it('throws InputError when encoding unknown permission key', () => {
+        expect(() => encodePermissionKeys(['fleet.read', 'unknown.permission']))
+            .toThrow(InputError)
+    })
+
+    it('throws InputError when decoding invalid packed value', () => {
+        expect(() => decodeFeatureKeys('not-hex', ACCESS_VERSION))
+            .toThrow(InputError)
+    })
+
+    it('uses explicit packed permissions over role defaults when present', () => {
+        const packed = encodePermissionKeys(['users.read'])
+        const set = effectivePermissionKeysForUser({
+            role: 'viewer',
+            permissionsPacked: packed,
+            permissionsVersion: ACCESS_VERSION
+        })
+
+        expect(set.has('users.read')).toBeTruthy()
+        expect(set.has('tracking.read')).toBeFalsy()
+    })
+
+    it('hasPermission and isFeatureEnabled validate unknown keys', () => {
+        expect(() => hasPermission({ role: 'viewer' }, 'bad.permission'))
+            .toThrow(InputError)
+        expect(() => isFeatureEnabled({}, 'bad.feature'))
+            .toThrow(InputError)
     })
 })

--- a/track-api/src/tracking/tracking.service.spec.js
+++ b/track-api/src/tracking/tracking.service.spec.js
@@ -3,6 +3,22 @@ const { errors: { LogicError, RequirementError, InputError } } = require('track-
 const argon2 = require('argon2')
 const trackingService = require('./tracking.service')
 
+async function expectServiceError(run, ErrorType, message, matcher = 'toBe') {
+    let caught
+    try {
+        await run()
+    } catch (error) {
+        caught = error
+    }
+
+    expect(caught).toBeInstanceOf(ErrorType)
+    if (matcher === 'toContain') {
+        expect(caught.message).toContain(message)
+        return
+    }
+    expect(caught.message).toBe(message)
+}
+
 describe('trackingService', () => {
     let name, surname, email, password
 
@@ -64,60 +80,30 @@ describe('trackingService', () => {
         it('should fail on incorrect id user', async () => {
             const wrongId = '5cb9998f2e59ee0009eac02c'
             const trackData = { serialNumber: '1234567890', latitude: lat, longitude: lon, speed: 1, status: 1, date: new Date().toISOString() }
-            try {
-                await trackingService.addTrack(wrongId, trackData)
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`user with id ${wrongId} doesn't exists`)
-            }
+            await expectServiceError(() => trackingService.addTrack(wrongId, trackData), LogicError, `user with id ${wrongId} doesn't exists`)
         })
 
         it('should fail on undefined id user', async () => {
             const trackData = { serialNumber: '1234567890', latitude: lat, longitude: lon, speed: 1, status: 1, date: new Date().toISOString() }
-            try {
-                await trackingService.addTrack(undefined, trackData)
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`id is not optional`)
-            }
+            await expectServiceError(() => trackingService.addTrack(undefined, trackData), RequirementError, `id is not optional`)
         })
 
         it('should fail on null id user', async () => {
             const trackData = { serialNumber: '1234567890', latitude: lat, longitude: lon, speed: 1, status: 1, date: new Date().toISOString() }
-            try {
-                await trackingService.addTrack(null, trackData)
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`id is not optional`)
-            }
+            await expectServiceError(() => trackingService.addTrack(null, trackData), RequirementError, `id is not optional`)
         })
 
         it('should fail on unexisting serial number tracker', async () => {
             const trackData = { serialNumber: '000_NO_EXIST', latitude: lat, longitude: lon, speed: 1, status: 1, date: new Date().toISOString() }
-            try {
-                await trackingService.addTrack(user.id, trackData)
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`Tracker with SN 000_NO_EXIST doesn't exists`)
-            }
+            await expectServiceError(() => trackingService.addTrack(user.id, trackData), LogicError, `Tracker with SN 000_NO_EXIST doesn't exists`)
         })
 
         it('should fail on undefined data track', async () => {
-            try {
-                await trackingService.addTrack(user.id, undefined)
-            } catch (error) {
-                expect(error).toBeInstanceOf(InputError)
-                expect(error.message).toBe('incorrect track info')
-            }
+            await expectServiceError(() => trackingService.addTrack(user.id, undefined), InputError, 'incorrect track info')
         })
 
         it('should fail on null data track', async () => {
-            try {
-                await trackingService.addTrack(user.id, null)
-            } catch (error) {
-                expect(error).toBeInstanceOf(InputError)
-                expect(error.message).toBe('incorrect track info')
-            }
+            await expectServiceError(() => trackingService.addTrack(user.id, null), InputError, 'incorrect track info')
         })
     })
 
@@ -228,21 +214,11 @@ describe('trackingService', () => {
         })
 
         it('should fail on undefined data track', async () => {
-            try {
-                await trackingService.addTrackTCP(undefined)
-            } catch (error) {
-                expect(error).toBeInstanceOf(InputError)
-                expect(error.message).toBe('incorrect track info')
-            }
+            await expectServiceError(() => trackingService.addTrackTCP(undefined), InputError, 'incorrect track info')
         })
 
         it('should fail on null data track', async () => {
-            try {
-                await trackingService.addTrackTCP(null)
-            } catch (error) {
-                expect(error).toBeInstanceOf(InputError)
-                expect(error.message).toBe('incorrect track info')
-            }
+            await expectServiceError(() => trackingService.addTrackTCP(null), InputError, 'incorrect track info')
         })
 
         it('should fail on out-of-range latitude', async () => {
@@ -255,12 +231,7 @@ describe('trackingService', () => {
                 date: new Date().toISOString()
             }
 
-            try {
-                await trackingService.addTrackTCP(trackData)
-            } catch (error) {
-                expect(error).toBeInstanceOf(InputError)
-                expect(error.message).toBe('latitude out of range')
-            }
+            await expectServiceError(() => trackingService.addTrackTCP(trackData), InputError, 'latitude out of range')
         })
     })
 
@@ -291,58 +262,28 @@ describe('trackingService', () => {
 
         it('should fail on incorrect user id', async () => {
             const wrongId = '5cb9998f2e59ee0009eac02c'
-            try {
-                await trackingService.retrieveLastTrack(wrongId, user.trackers[0].id)
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`user with id ${wrongId} doesn't exists`)
-            }
+            await expectServiceError(() => trackingService.retrieveLastTrack(wrongId, user.trackers[0].id), LogicError, `user with id ${wrongId} doesn't exists`)
         })
 
         it('should fail on undefined id user', async () => {
-            try {
-                await trackingService.retrieveLastTrack(undefined, user.trackers[0].id)
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`id is not optional`)
-            }
+            await expectServiceError(() => trackingService.retrieveLastTrack(undefined, user.trackers[0].id), RequirementError, `id is not optional`)
         })
 
         it('should fail on null id user', async () => {
-            try {
-                await trackingService.retrieveLastTrack(null, user.trackers[0].id)
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`id is not optional`)
-            }
+            await expectServiceError(() => trackingService.retrieveLastTrack(null, user.trackers[0].id), RequirementError, `id is not optional`)
         })
 
         it('should fail on unexisting tracker id', async () => {
             const badId = 'Bad_Tracker_Id'
-            try {
-                await trackingService.retrieveLastTrack(user.id, badId)
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`Tracker with id ${badId} doesn't exists`)
-            }
+            await expectServiceError(() => trackingService.retrieveLastTrack(user.id, badId), LogicError, `Tracker with id ${badId} doesn't exists`)
         })
 
         it('should fail on undefined tracker id', async () => {
-            try {
-                await trackingService.retrieveLastTrack(user.id, undefined)
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe('trackerID is not optional')
-            }
+            await expectServiceError(() => trackingService.retrieveLastTrack(user.id, undefined), RequirementError, 'trackerID is not optional')
         })
 
         it('should fail on null tracker id', async () => {
-            try {
-                await trackingService.retrieveLastTrack(user.id, null)
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe('trackerID is not optional')
-            }
+            await expectServiceError(() => trackingService.retrieveLastTrack(user.id, null), RequirementError, 'trackerID is not optional')
         })
     })
 
@@ -383,30 +324,15 @@ describe('trackingService', () => {
 
         it('should fail on incorrect user id', async () => {
             const wrongId = '5cb9998f2e59ee0009eac02c'
-            try {
-                await trackingService.retrieveAllLastTracks(wrongId)
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`user with id ${wrongId} doesn't exists`)
-            }
+            await expectServiceError(() => trackingService.retrieveAllLastTracks(wrongId), LogicError, `user with id ${wrongId} doesn't exists`)
         })
 
         it('should fail on undefined id user', async () => {
-            try {
-                await trackingService.retrieveAllLastTracks(undefined)
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`id is not optional`)
-            }
+            await expectServiceError(() => trackingService.retrieveAllLastTracks(undefined), RequirementError, `id is not optional`)
         })
 
         it('should fail on null id user', async () => {
-            try {
-                await trackingService.retrieveAllLastTracks(null)
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`id is not optional`)
-            }
+            await expectServiceError(() => trackingService.retrieveAllLastTracks(null), RequirementError, `id is not optional`)
         })
 
         it('should return empty array for user with no trackers', async () => {
@@ -451,77 +377,37 @@ describe('trackingService', () => {
 
         it('should fail on incorrect user id', async () => {
             const wrongId = '5cb9998f2e59ee0009eac02c'
-            try {
-                await trackingService.retrieveRangeOfTracks(wrongId, user.trackers[0].id, startTime, endTime)
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toBe(`user with id ${wrongId} doesn't exists`)
-            }
+            await expectServiceError(() => trackingService.retrieveRangeOfTracks(wrongId, user.trackers[0].id, startTime, endTime), LogicError, `user with id ${wrongId} doesn't exists`)
         })
 
         it('should fail when no tracks exist in range', async () => {
             const past = '2000-01-01T00:00:00.000Z'
             const pastEnd = '2000-01-02T00:00:00.000Z'
-            try {
-                await trackingService.retrieveRangeOfTracks(user.id, user.trackers[0].id, past, pastEnd)
-            } catch (error) {
-                expect(error).toBeInstanceOf(LogicError)
-                expect(error.message).toContain('Tracker without tracks between')
-            }
+            await expectServiceError(() => trackingService.retrieveRangeOfTracks(user.id, user.trackers[0].id, past, pastEnd), LogicError, 'Tracker without tracks between', 'toContain')
         })
 
         it('should fail on undefined id user', async () => {
-            try {
-                await trackingService.retrieveRangeOfTracks(undefined, user.trackers[0].id, startTime, endTime)
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`id is not optional`)
-            }
+            await expectServiceError(() => trackingService.retrieveRangeOfTracks(undefined, user.trackers[0].id, startTime, endTime), RequirementError, `id is not optional`)
         })
 
         it('should fail on null id user', async () => {
-            try {
-                await trackingService.retrieveRangeOfTracks(null, user.trackers[0].id, startTime, endTime)
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe(`id is not optional`)
-            }
+            await expectServiceError(() => trackingService.retrieveRangeOfTracks(null, user.trackers[0].id, startTime, endTime), RequirementError, `id is not optional`)
         })
 
         it('should fail on undefined tracker id', async () => {
-            try {
-                await trackingService.retrieveRangeOfTracks(user.id, undefined, startTime, endTime)
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe('trackerID is not optional')
-            }
+            await expectServiceError(() => trackingService.retrieveRangeOfTracks(user.id, undefined, startTime, endTime), RequirementError, 'trackerID is not optional')
         })
 
         it('should fail on null tracker id', async () => {
-            try {
-                await trackingService.retrieveRangeOfTracks(user.id, null, startTime, endTime)
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe('trackerID is not optional')
-            }
+            await expectServiceError(() => trackingService.retrieveRangeOfTracks(user.id, null, startTime, endTime), RequirementError, 'trackerID is not optional')
         })
 
         it('should fail on undefined start time', async () => {
-            try {
-                await trackingService.retrieveRangeOfTracks(user.id, user.trackers[0].id, undefined, endTime)
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe('startTime is not optional')
-            }
+            await expectServiceError(() => trackingService.retrieveRangeOfTracks(user.id, user.trackers[0].id, undefined, endTime), RequirementError, 'startTime is not optional')
         })
 
         it('should fail on undefined end time', async () => {
-            try {
-                await trackingService.retrieveRangeOfTracks(user.id, user.trackers[0].id, startTime, undefined)
-            } catch (error) {
-                expect(error).toBeInstanceOf(RequirementError)
-                expect(error.message).toBe('endTime is not optional')
-            }
+            await expectServiceError(() => trackingService.retrieveRangeOfTracks(user.id, user.trackers[0].id, startTime, undefined), RequirementError, 'endTime is not optional')
         })
     })
 })

--- a/track-app/Dockerfile
+++ b/track-app/Dockerfile
@@ -9,7 +9,7 @@ COPY track-utils/package.json ./track-utils/
 COPY track-app/package.json ./track-app/
 
 # Install dependencies
-RUN npm ci --workspace=track-app --include-workspace-root
+RUN npm ci --workspace=track-app --include-workspace-root --include=dev --include=optional
 
 # Copy source code
 COPY track-data/ ./track-data/

--- a/track-app/package.json
+++ b/track-app/package.json
@@ -33,6 +33,7 @@
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^6.0.1",
+    "esbuild": "^0.27.7",
     "jsdom": "^29.0.2",
     "postcss": "^8.4.49",
     "tailwindcss": "^4.1.14",

--- a/track-tcp/__tests__/server.test.js
+++ b/track-tcp/__tests__/server.test.js
@@ -12,6 +12,7 @@ const net = require('net')
 
 const VALID_FRAME = '*HQ,9900110011,V1,120000,A,41.3902,N,002.1540,E,090.80,208,080426,FFFF9FFF,214,03,2126,1860#'
 const INVALID_FRAME = '*HQ,9900110011,V1,120000,V,41.3902,N,002.1540,E,090.80,208,080426,FFFF9FFF,214,03,2126,1860#'
+const VALID_FRAME_2 = '*HQ,9900110022,V1,120100,A,41.3902,N,002.1540,E,070.20,208,080426,FFFF9FFF,214,03,2126,1860#'
 
 /**
  * Connect a raw TCP socket to the server, send a payload, then wait for the
@@ -28,6 +29,30 @@ function sendPayload(port, payload) {
             client.destroy()
             resolve()
         }, 150)
+    })
+}
+
+/**
+ * Connect a raw TCP socket, send multiple chunks in sequence and allow server
+ * buffering logic to assemble complete frames.
+ */
+function sendPayloadInChunks(port, chunks) {
+    return new Promise((resolve, reject) => {
+        const client = net.createConnection({ port }, async () => {
+            try {
+                for (const chunk of chunks) {
+                    client.write(chunk)
+                    await new Promise((r) => setTimeout(r, 20))
+                }
+            } catch (err) {
+                reject(err)
+            }
+        })
+        client.on('error', reject)
+        setTimeout(() => {
+            client.destroy()
+            resolve()
+        }, 180)
     })
 }
 
@@ -111,6 +136,46 @@ describe('track-tcp server — real TCP socket wiring', () => {
         await sendPayload(port, INVALID_FRAME)
 
         expect(mockCall).not.toHaveBeenCalled()
+    })
+
+    it('processes multiple complete frames received in a single TCP chunk', async () => {
+        mockCall.mockResolvedValue({})
+
+        await sendPayload(port, `${VALID_FRAME}${VALID_FRAME_2}`)
+
+        expect(mockCall).toHaveBeenCalledTimes(2)
+        expect(mockCall).toHaveBeenNthCalledWith(
+            1,
+            expect.any(String),
+            expect.objectContaining({
+                data: expect.objectContaining({ serialNumber: '9900110011' })
+            })
+        )
+        expect(mockCall).toHaveBeenNthCalledWith(
+            2,
+            expect.any(String),
+            expect.objectContaining({
+                data: expect.objectContaining({ serialNumber: '9900110022' })
+            })
+        )
+    })
+
+    it('buffers a partial frame and only ingests when delimiter # arrives', async () => {
+        mockCall.mockResolvedValue({})
+
+        const cut = Math.floor(VALID_FRAME.length / 2)
+        const firstChunk = VALID_FRAME.slice(0, cut)
+        const secondChunk = VALID_FRAME.slice(cut)
+
+        await sendPayloadInChunks(port, [firstChunk, secondChunk])
+
+        expect(mockCall).toHaveBeenCalledTimes(1)
+        expect(mockCall).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+                data: expect.objectContaining({ serialNumber: '9900110011' })
+            })
+        )
     })
 
     it('server exports a net.Server instance', () => {


### PR DESCRIPTION
## Resumen
- Refuerza specs de servicios (`tracking`, `fleet`, `poi`) eliminando patrones frágiles de assertions de errores.
- Añade cobertura de alto valor para framing TCP por delimitador `#` (frames concatenados y frames partidos).
- Amplía cobertura de `access-control` con casos de versionado, claves inválidas y precedencia de permisos explícitos.
- Corrige build de `track-app` en Docker (`esbuild` explícito + instalación con `--include=dev --include=optional`).

## Validación
- `npm test -- src/shared/access-control.spec.js`
- `npm test -- src/tracking/tracking.service.spec.js src/fleet/fleet.service.spec.js src/poi/poi.service.spec.js`
- `npm test -- server.test.js` (en `track-tcp`)
- `npm run build -w track-app`
- `docker build -f track-app/Dockerfile -t tortoise-gps-track-app:test .`

## Riesgo
- Bajo: cambios acotados a tests y build de frontend en Docker.
