### PR TITLE
fix(track-app): evitar fallo de build por dependencia de vite/rollup

### DIFF
--- a/track-app/Dockerfile
+++ b/track-app/Dockerfile
@@ -4,12 +4,15 @@ WORKDIR /app
 
 # Copy workspace files
 COPY package.json package-lock.json ./
+COPY track-api/package.json ./track-api/
 COPY track-data/package.json ./track-data/
+COPY track-tcp/package.json ./track-tcp/
 COPY track-utils/package.json ./track-utils/
 COPY track-app/package.json ./track-app/
+COPY tracker-simulator/package.json ./tracker-simulator/
 
 # Install dependencies
-RUN npm ci --workspace=track-app --include-workspace-root --include=dev --include=optional
+RUN npm ci --include=dev --include=optional
 
 # Copy source code
 COPY track-data/ ./track-data/


### PR DESCRIPTION
## Resumen
- hace la instalación de dependencias del build de `track-app` determinista en Docker
- evita instalaciones parciales por workspace que podían romper `vite build` con `ERR_MODULE_NOT_FOUND` para `rollup`

## Cambios
- en `track-app/Dockerfile`, copia `package.json` de todos los workspaces antes de `npm ci`
- reemplaza `npm ci --workspace=track-app ...` por `npm ci --include=dev --include=optional`

## Verificación
- `docker build --no-cache -f track-app/Dockerfile -t local-track-app-test .`
- `docker compose build track-app`
