### PR TITLE
fix(track-app): estabilizar build de Vite 8 (target/minify)

### DIFF
--- a/track-app/vite.config.js
+++ b/track-app/vite.config.js
@@ -42,6 +42,11 @@ export default defineConfig({
     }
   },
   build: {
+    // Vite 8 uses `oxc` minifier by default. In some environments it fails when
+    // lowering vendor bundles (e.g. react-toastify) to older browser targets.
+    // Keep a stable target/minifier combo for deterministic Docker builds.
+    target: 'es2020',
+    minify: 'esbuild',
     rolldownOptions: {
       output: {
         manualChunks(id) {


### PR DESCRIPTION
## Resumen
- corrige fallo de build al minificar/transpilar bundle de vendor con Vite 8
- evita el error `Transforming destructuring to the configured target environment is not supported yet`

## Cambios
- en `track-app/vite.config.js` se fija `build.target: 'es2020'`
- en `track-app/vite.config.js` se fija `build.minify: 'esbuild'` (evitando el path por defecto de `oxc` en este caso)

## Verificación
- `docker compose build track-app --no-cache`
