### PR TITLE
Refactor backoffice a rutas por sección

### DIFF
--- a/track-app/src/components/App.tsx
+++ b/track-app/src/components/App.tsx
@@ -37,9 +37,46 @@ interface TrackingDetailRouteProps {
   darkmode: boolean
 }
 
+type BackofficeSection = 'companies' | 'users' | 'trackers'
+
+function normalizeBackofficeSection(section?: string): BackofficeSection {
+  if (section === 'users' || section === 'trackers') return section
+  return 'companies'
+}
+
 function TrackingDetailRoute({ darkmode }: TrackingDetailRouteProps) {
   const { serialNumber } = useParams<{ serialNumber: string }>()
   return <TrackingDetail darkmode={darkmode} serialNumber={serialNumber ?? ''} />
+}
+
+interface BackofficeRouteProps {
+  canReadUsers: boolean
+  canCreateUsers: boolean
+  canUpdateUsers: boolean
+  canCreateTrackers: boolean
+}
+
+function BackofficeRoute({
+  canReadUsers,
+  canCreateUsers,
+  canUpdateUsers,
+  canCreateTrackers
+}: BackofficeRouteProps) {
+  const { section, entityId } = useParams<{ section: string, entityId?: string }>()
+  const normalizedSection = normalizeBackofficeSection(section)
+  if (section !== normalizedSection) return <Navigate to="/backoffice/companies" replace />
+  if (normalizedSection === 'trackers' && entityId) return <Navigate to="/backoffice/trackers" replace />
+
+  return (
+    <Backoffice
+      section={normalizedSection}
+      entityId={entityId}
+      canReadUsers={canReadUsers}
+      canCreateUsers={canCreateUsers}
+      canUpdateUsers={canUpdateUsers}
+      canCreateTrackers={canCreateTrackers}
+    />
+  )
 }
 
 function App() {
@@ -106,7 +143,10 @@ function App() {
   const handleTrackings = () => navigate('/trackers')
   const handleProfile   = () => navigate('/profile')
   const handleUsers = () => navigate('/users')
-  const handleBackoffice = () => navigate('/backoffice')
+  const handleBackoffice = () => navigate('/backoffice/companies')
+  const handleBackofficeCompanies = () => navigate('/backoffice/companies')
+  const handleBackofficeUsers = () => navigate('/backoffice/users')
+  const handleBackofficeTrackers = () => navigate('/backoffice/trackers')
   const handleDarkMode  = () => setDarkmode(prev => !prev)
 
   // ── shorthand for protected routes ───────────────────────────────────────
@@ -132,6 +172,11 @@ function App() {
           onTrackings={handleTrackings}
           onBackoffice={handleBackoffice}
           showBackoffice={canAccessBackoffice}
+          onBackofficeCompanies={handleBackofficeCompanies}
+          onBackofficeUsers={handleBackofficeUsers}
+          onBackofficeTrackers={handleBackofficeTrackers}
+          showBackofficeUsers={canReadUsers || canCreateUsers || canUpdateUsers}
+          showBackofficeTrackers={canCreateTrackers}
           onLogout={handleLogout}
         />
       )}
@@ -153,10 +198,22 @@ function App() {
 
         <Route path="/trackers"     element={guard(<Trackings />)} />
         <Route path="/trackers/new" element={guard(<TrackingsNew />)} />
+        <Route path="/backoffice" element={<Navigate to="/backoffice/companies" replace />} />
         <Route
-          path="/backoffice"
+          path="/backoffice/:section"
           element={staffGuard(
-            <Backoffice
+            <BackofficeRoute
+              canReadUsers={canReadUsers}
+              canCreateUsers={canCreateUsers}
+              canUpdateUsers={canUpdateUsers}
+              canCreateTrackers={canCreateTrackers}
+            />
+          )}
+        />
+        <Route
+          path="/backoffice/:section/:entityId"
+          element={staffGuard(
+            <BackofficeRoute
               canReadUsers={canReadUsers}
               canCreateUsers={canCreateUsers}
               canUpdateUsers={canUpdateUsers}

--- a/track-app/src/components/Backoffice/index.tsx
+++ b/track-app/src/components/Backoffice/index.tsx
@@ -4,6 +4,7 @@ import DataTable, { Column } from '../shared/DataTable'
 import { useBackoffice, BackofficeCompany, BackofficeUser } from '../../hooks/useBackoffice'
 import { FEATURE_KEYS, PERMISSION_KEYS, permissionTemplateForRole } from './access-catalog'
 import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
 
 function toggleInArray(list: string[], value: string): string[] {
   return list.includes(value)
@@ -12,21 +13,24 @@ function toggleInArray(list: string[], value: string): string[] {
 }
 
 interface BackofficeProps {
+  section: 'companies' | 'users' | 'trackers'
+  entityId?: string
   canReadUsers?: boolean
   canCreateUsers?: boolean
   canUpdateUsers?: boolean
   canCreateTrackers?: boolean
 }
 
-type BackofficeTab = 'companies' | 'users'
-
 function Backoffice({
+  section,
+  entityId,
   canReadUsers = true,
   canCreateUsers = true,
   canUpdateUsers = true,
   canCreateTrackers = true
 }: BackofficeProps) {
   const { t } = useTranslation()
+  const navigate = useNavigate()
   const labelClass = 'mb-2 block text-sm font-semibold'
   const inputClass = 'glass-input-base w-full rounded-xl border px-3 py-2 text-sm outline-none transition'
   const primaryButtonClass = 'inline-flex items-center justify-center rounded-full border border-amber-500 bg-amber-400 px-4 py-2 text-sm font-semibold text-slate-800 transition hover:brightness-105'
@@ -34,10 +38,14 @@ function Backoffice({
   const sectionClass = 'pb-8 border-b space-y-4'
   const checkboxesWrapClass = 'flex flex-wrap gap-x-4 gap-y-2'
 
+  const isCompaniesSection = section === 'companies'
+  const isUsersSection = section === 'users'
+  const isTrackersSection = section === 'trackers'
+  const canSeeUsersSection = canReadUsers || canCreateUsers || canUpdateUsers
+  const shouldLoadUsers = isUsersSection && canReadUsers
+
   const [usersPage, setUsersPage] = useState(1)
-  const { companies, users, usersTotalCount, loading, createCompany, createUser, createTracker, updateCompany, updateUser } = useBackoffice(usersPage, 20, canReadUsers)
-  const canSeeUsersTab = canReadUsers || canCreateUsers || canUpdateUsers
-  const [activeTab, setActiveTab] = useState<BackofficeTab>('companies')
+  const { companies, users, usersTotalCount, loading, createCompany, createUser, createTracker, updateCompany, updateUser } = useBackoffice(usersPage, 20, shouldLoadUsers)
   const [companyForm, setCompanyForm] = useState({
     name: '',
     active: true,
@@ -102,10 +110,6 @@ function Backoffice({
       featureKeys: [...FEATURE_KEYS]
     })
   }
-
-  useEffect(() => {
-    if (!canSeeUsersTab && activeTab === 'users') setActiveTab('companies')
-  }, [activeTab, canSeeUsersTab])
 
   const onCreateUser = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -172,8 +176,7 @@ function Backoffice({
     permissionKeys: [] as string[]
   })
 
-  const onPickCompany = (companyId: string) => {
-    setSelectedCompanyId(companyId)
+  const fillCompanyEdit = (companyId: string) => {
     const company = companies.find(item => item.id === companyId)
     if (!company) return
     setCompanyEdit({
@@ -184,8 +187,7 @@ function Backoffice({
     })
   }
 
-  const onPickUser = (userId: string) => {
-    setSelectedUserId(userId)
+  const fillUserEdit = (userId: string) => {
     const user = users.find(item => item.id === userId)
     if (!user) return
     setUserEdit({
@@ -197,6 +199,22 @@ function Backoffice({
       companyId: user.companyId || '',
       permissionKeys: [...user.permissionKeys]
     })
+  }
+
+  const onPickCompany = (companyId: string) => {
+    if (!companyId) {
+      navigate('/backoffice/companies')
+      return
+    }
+    navigate(`/backoffice/companies/${companyId}`)
+  }
+
+  const onPickUser = (userId: string) => {
+    if (!userId) {
+      navigate('/backoffice/users')
+      return
+    }
+    navigate(`/backoffice/users/${userId}`)
   }
 
   const onUpdateCompany = async (e: React.FormEvent) => {
@@ -219,31 +237,54 @@ function Backoffice({
     })
   }
 
+  useEffect(() => {
+    if (!isCompaniesSection) return
+    const nextCompanyId = entityId || ''
+    if (nextCompanyId !== selectedCompanyId) setSelectedCompanyId(nextCompanyId)
+    if (nextCompanyId) fillCompanyEdit(nextCompanyId)
+  }, [isCompaniesSection, entityId, selectedCompanyId, companies])
+
+  useEffect(() => {
+    if (!isUsersSection) return
+    const nextUserId = entityId || ''
+    if (nextUserId !== selectedUserId) setSelectedUserId(nextUserId)
+    if (nextUserId) fillUserEdit(nextUserId)
+  }, [isUsersSection, entityId, selectedUserId, users])
+
   return (
     <PageShell title={t('backoffice.title')}>
       {loading && <p className="text-center text-[var(--text-muted)]">{t('backoffice.loading')}</p>}
 
-      <div className="mb-6 flex gap-2">
+      <div className="mb-6 flex flex-wrap gap-2">
         <button
-          className={`rounded-full border px-3 py-1.5 text-sm font-medium ${activeTab === 'companies' ? 'bg-[var(--bg-glass-strong)] text-[var(--text-primary)]' : 'bg-[var(--bg-glass)] text-[var(--text-secondary)]'}`}
-          onClick={() => setActiveTab('companies')}
+          className={`rounded-full border px-3 py-1.5 text-sm font-medium ${isCompaniesSection ? 'bg-[var(--bg-glass-strong)] text-[var(--text-primary)]' : 'bg-[var(--bg-glass)] text-[var(--text-secondary)]'}`}
+          onClick={() => navigate('/backoffice/companies')}
           type="button"
         >
-          {t('backoffice.companiesTab')}
+          {t('backoffice.companies')}
         </button>
-        {canSeeUsersTab && (
+        {canSeeUsersSection && (
           <button
-            className={`rounded-full border px-3 py-1.5 text-sm font-medium ${activeTab === 'users' ? 'bg-[var(--bg-glass-strong)] text-[var(--text-primary)]' : 'bg-[var(--bg-glass)] text-[var(--text-secondary)]'}`}
-            onClick={() => setActiveTab('users')}
+            className={`rounded-full border px-3 py-1.5 text-sm font-medium ${isUsersSection ? 'bg-[var(--bg-glass-strong)] text-[var(--text-primary)]' : 'bg-[var(--bg-glass)] text-[var(--text-secondary)]'}`}
+            onClick={() => navigate('/backoffice/users')}
             type="button"
           >
-            {t('backoffice.usersTab')}
+            {t('backoffice.users')}
+          </button>
+        )}
+        {canCreateTrackers && (
+          <button
+            className={`rounded-full border px-3 py-1.5 text-sm font-medium ${isTrackersSection ? 'bg-[var(--bg-glass-strong)] text-[var(--text-primary)]' : 'bg-[var(--bg-glass)] text-[var(--text-secondary)]'}`}
+            onClick={() => navigate('/backoffice/trackers')}
+            type="button"
+          >
+            {t('trackers.title')}
           </button>
         )}
       </div>
       <div className="space-y-8">
 
-      {activeTab === 'companies' && (
+      {isCompaniesSection && (
       <>
       <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
         <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.createCompany')}</h3>
@@ -277,57 +318,20 @@ function Backoffice({
         </form>
       </section>
 
-      {canCreateTrackers && (
-      <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
-        <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.createTracker')}</h3>
-        <form onSubmit={onCreateTracker}>
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-            <div>
-              <label className={labelClass}>{t('trackers.serialNumber')}</label>
-              <input
-                className={inputClass}
-                value={trackerForm.serialNumber}
-                onChange={(e) => setTrackerForm(prev => ({ ...prev, serialNumber: e.target.value }))}
-                required
-              />
-            </div>
-            <div>
-              <label className={labelClass}>{t('ui.alias')}</label>
-              <input
-                className={inputClass}
-                value={trackerForm.alias}
-                onChange={(e) => setTrackerForm(prev => ({ ...prev, alias: e.target.value }))}
-                placeholder={t('ui.optional')}
-              />
-            </div>
-            <div className="md:col-span-2">
-              <label className={labelClass}>{t('backoffice.company')}</label>
-              <select
-                className={inputClass}
-                value={trackerForm.companyId}
-                onChange={(e) => setTrackerForm(prev => ({ ...prev, companyId: e.target.value }))}
-                required
-              >
-                <option value="">{t('backoffice.selectCompany')}</option>
-                {companyOptions.map((company) => (
-                  <option key={company.id} value={company.id}>{company.label}</option>
-                ))}
-              </select>
-            </div>
-          </div>
-          <button className={`${primaryButtonClass} mt-6`} type="submit">{t('backoffice.createTracker')}</button>
-        </form>
-      </section>
-      )}
-
       <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
         <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.companies')}</h3>
-        <DataTable columns={COMPANY_COLUMNS} rows={companies} emptyMessage={t('backoffice.noCompanies')} variant="flat" />
+        <DataTable
+          columns={COMPANY_COLUMNS}
+          rows={companies}
+          emptyMessage={t('backoffice.noCompanies')}
+          variant="flat"
+          onEdit={(company) => navigate(`/backoffice/companies/${company.id}`)}
+        />
       </section>
       </>
       )}
 
-      {activeTab === 'users' && canCreateUsers && (
+      {isUsersSection && canCreateUsers && (
       <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
         <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.createUser')}</h3>
         <form onSubmit={onCreateUser}>
@@ -407,7 +411,7 @@ function Backoffice({
       </section>
       )}
 
-      {activeTab === 'companies' && (
+      {isCompaniesSection && (
       <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
         <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.editCompany')}</h3>
         <div className="mb-4">
@@ -456,11 +460,11 @@ function Backoffice({
       </section>
       )}
 
-      {activeTab === 'users' && canReadUsers && canUpdateUsers && (
+      {isUsersSection && canReadUsers && canUpdateUsers && (
       <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
         <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.editUser')}</h3>
         <div className="mb-4">
-          <label className={labelClass}>{t('backoffice.usersTab')}</label>
+          <label className={labelClass}>{t('backoffice.users')}</label>
           <select className={inputClass} value={selectedUserId} onChange={(e) => onPickUser(e.target.value)}>
             <option value="">{t('backoffice.selectUser')}</option>
             {users.map((user) => (
@@ -543,7 +547,7 @@ function Backoffice({
       </section>
       )}
 
-      {activeTab === 'users' && canReadUsers && (
+      {isUsersSection && canReadUsers && (
       <section>
         <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.users')}</h3>
         <DataTable
@@ -551,6 +555,7 @@ function Backoffice({
           rows={users}
           emptyMessage={t('backoffice.noUsers')}
           variant="flat"
+          onEdit={(user) => navigate(`/backoffice/users/${user.id}`)}
           pageSize={20}
           serverPagination={{
             enabled: true,
@@ -559,6 +564,49 @@ function Backoffice({
             onPageChange: setUsersPage
           }}
         />
+      </section>
+      )}
+
+      {isTrackersSection && canCreateTrackers && (
+      <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
+        <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.createTracker')}</h3>
+        <form onSubmit={onCreateTracker}>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div>
+              <label className={labelClass}>{t('trackers.serialNumber')}</label>
+              <input
+                className={inputClass}
+                value={trackerForm.serialNumber}
+                onChange={(e) => setTrackerForm(prev => ({ ...prev, serialNumber: e.target.value }))}
+                required
+              />
+            </div>
+            <div>
+              <label className={labelClass}>{t('ui.alias')}</label>
+              <input
+                className={inputClass}
+                value={trackerForm.alias}
+                onChange={(e) => setTrackerForm(prev => ({ ...prev, alias: e.target.value }))}
+                placeholder={t('ui.optional')}
+              />
+            </div>
+            <div className="md:col-span-2">
+              <label className={labelClass}>{t('backoffice.company')}</label>
+              <select
+                className={inputClass}
+                value={trackerForm.companyId}
+                onChange={(e) => setTrackerForm(prev => ({ ...prev, companyId: e.target.value }))}
+                required
+              >
+                <option value="">{t('backoffice.selectCompany')}</option>
+                {companyOptions.map((company) => (
+                  <option key={company.id} value={company.id}>{company.label}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <button className={`${primaryButtonClass} mt-6`} type="submit">{t('backoffice.createTracker')}</button>
+        </form>
       </section>
       )}
       </div>

--- a/track-app/src/components/Navbar/index.tsx
+++ b/track-app/src/components/Navbar/index.tsx
@@ -14,6 +14,11 @@ interface NavbarProps {
   onTrackings: () => void
   onBackoffice?: () => void
   showBackoffice?: boolean
+  onBackofficeCompanies?: () => void
+  onBackofficeUsers?: () => void
+  onBackofficeTrackers?: () => void
+  showBackofficeUsers?: boolean
+  showBackofficeTrackers?: boolean
   onLogout: () => void
 }
 
@@ -26,6 +31,11 @@ function Navbar({
   onTrackings,
   onBackoffice,
   showBackoffice = false,
+  onBackofficeCompanies,
+  onBackofficeUsers,
+  onBackofficeTrackers,
+  showBackofficeUsers = false,
+  showBackofficeTrackers = false,
   onLogout
 }: NavbarProps) {
   const { t } = useTranslation()
@@ -41,6 +51,7 @@ function Navbar({
   const close = () => setMenuOpen(false)
   const toggleDesktopMinimized = () => setDesktopMinimized(prev => !prev)
   const canMinimize = !isMobile && location.pathname.startsWith('/home')
+  const isBackofficeMode = showBackoffice && location.pathname.startsWith('/backoffice')
 
   useEffect(() => {
     const handleResize = () => setIsMobile(window.innerWidth < 768)
@@ -91,15 +102,34 @@ function Navbar({
         className={`nav-home__menu ${menuVisible ? 'nav-home__menu--visible' : 'nav-home__menu--hidden'} ${isMobile ? 'nav-home__menu--mobile' : 'nav-home__menu--desktop'}`}
       >
         <div className="nav-home__links flex flex-col gap-1 md:flex-row md:items-center md:gap-0">
-          <button className="inline-flex cursor-pointer items-center rounded-lg px-3 py-2 text-sm font-semibold" onClick={() => { onHome(); close() }} type="button">{t('nav.home')}</button>
-          <button className="inline-flex cursor-pointer items-center rounded-lg px-3 py-2 text-sm font-semibold" onClick={() => { onProfile(); close() }} type="button">{t('nav.profile')}</button>
-          {showUsers && onUsers && (
-            <button className="inline-flex cursor-pointer items-center rounded-lg px-3 py-2 text-sm font-semibold" onClick={() => { onUsers(); close() }} type="button">{t('nav.users')}</button>
+          {!isBackofficeMode && (
+            <>
+              <button className="inline-flex cursor-pointer items-center rounded-lg px-3 py-2 text-sm font-semibold" onClick={() => { onHome(); close() }} type="button">{t('nav.home')}</button>
+              <button className="inline-flex cursor-pointer items-center rounded-lg px-3 py-2 text-sm font-semibold" onClick={() => { onProfile(); close() }} type="button">{t('nav.profile')}</button>
+              {showUsers && onUsers && (
+                <button className="inline-flex cursor-pointer items-center rounded-lg px-3 py-2 text-sm font-semibold" onClick={() => { onUsers(); close() }} type="button">{t('nav.users')}</button>
+              )}
+              <button className="inline-flex cursor-pointer items-center rounded-lg px-3 py-2 text-sm font-semibold" onClick={() => { onPlaces(); close() }} type="button">{t('nav.places')}</button>
+              <button className="inline-flex cursor-pointer items-center rounded-lg px-3 py-2 text-sm font-semibold" onClick={() => { onTrackings(); close() }} type="button">{t('nav.trackers')}</button>
+              {showBackoffice && onBackoffice && (
+                <button className="inline-flex cursor-pointer items-center rounded-lg px-3 py-2 text-sm font-semibold" onClick={() => { onBackoffice(); close() }} type="button">{t('nav.backoffice')}</button>
+              )}
+            </>
           )}
-          <button className="inline-flex cursor-pointer items-center rounded-lg px-3 py-2 text-sm font-semibold" onClick={() => { onPlaces(); close() }} type="button">{t('nav.places')}</button>
-          <button className="inline-flex cursor-pointer items-center rounded-lg px-3 py-2 text-sm font-semibold" onClick={() => { onTrackings(); close() }} type="button">{t('nav.trackers')}</button>
-          {showBackoffice && onBackoffice && (
-            <button className="inline-flex cursor-pointer items-center rounded-lg px-3 py-2 text-sm font-semibold" onClick={() => { onBackoffice(); close() }} type="button">{t('nav.backoffice')}</button>
+          {isBackofficeMode && (
+            <>
+              {onBackofficeCompanies && (
+                <button className="inline-flex cursor-pointer items-center rounded-lg px-3 py-2 text-sm font-semibold" onClick={() => { onBackofficeCompanies(); close() }} type="button">{t('backoffice.companies')}</button>
+              )}
+              {showBackofficeUsers && onBackofficeUsers && (
+                <button className="inline-flex cursor-pointer items-center rounded-lg px-3 py-2 text-sm font-semibold" onClick={() => { onBackofficeUsers(); close() }} type="button">{t('backoffice.users')}</button>
+              )}
+              {showBackofficeTrackers && onBackofficeTrackers && (
+                <button className="inline-flex cursor-pointer items-center rounded-lg px-3 py-2 text-sm font-semibold" onClick={() => { onBackofficeTrackers(); close() }} type="button">{t('trackers.title')}</button>
+              )}
+              <button className="inline-flex cursor-pointer items-center rounded-lg px-3 py-2 text-sm font-semibold" onClick={() => { onHome(); close() }} type="button">{t('nav.home')}</button>
+              <button className="inline-flex cursor-pointer items-center rounded-lg px-3 py-2 text-sm font-semibold" onClick={() => { onProfile(); close() }} type="button">{t('nav.profile')}</button>
+            </>
           )}
         </div>
 

--- a/track-app/src/components/shared/DataTable.tsx
+++ b/track-app/src/components/shared/DataTable.tsx
@@ -11,6 +11,7 @@ export interface Column<T> {
 interface DataTableProps<T extends object> {
   columns: Column<T>[]
   rows: T[]
+  onEdit?: (row: T) => void
   onDelete?: (row: T) => void
   emptyMessage?: string
   pageSize?: number
@@ -26,6 +27,7 @@ interface DataTableProps<T extends object> {
 function DataTable<T extends object>({
   columns,
   rows,
+  onEdit,
   onDelete,
   emptyMessage,
   pageSize = 20,
@@ -90,7 +92,7 @@ function DataTable<T extends object>({
               {columns.map(col => (
                 <th key={String(col.key)} className={headerClass} style={{ borderColor: 'var(--border-default)' }}>{col.label}</th>
               ))}
-              {onDelete && <th style={{ width: '80px', borderColor: 'var(--border-default)' }} className={headerClass}>{t('ui.actions')}</th>}
+              {(onEdit || onDelete) && <th style={{ width: '140px', borderColor: 'var(--border-default)' }} className={headerClass}>{t('ui.actions')}</th>}
             </tr>
           </thead>
           <tbody>
@@ -103,14 +105,28 @@ function DataTable<T extends object>({
                       : String((row as Record<string, unknown>)[col.key as string] ?? '')}
                   </td>
                 ))}
-                {onDelete && (
+                {(onEdit || onDelete) && (
                   <td className="border-b px-3 py-2 align-middle" style={{ borderColor: 'var(--border-default)' }}>
-                    <button
-                      className="inline-flex items-center justify-center rounded-full border border-red-700 bg-transparent px-3 py-1.5 text-xs font-semibold text-red-700 transition hover:bg-red-100"
-                      onClick={() => onDelete(row)}
-                    >
-                      {t('ui.delete')}
-                    </button>
+                    <div className="flex items-center gap-2">
+                      {onEdit && (
+                        <button
+                          className="inline-flex items-center justify-center rounded-full border border-[var(--border-default)] bg-[var(--glass-input)] px-3 py-1.5 text-xs font-semibold text-[var(--text-primary)] transition hover:brightness-105"
+                          onClick={() => onEdit(row)}
+                          type="button"
+                        >
+                          {t('ui.edit')}
+                        </button>
+                      )}
+                      {onDelete && (
+                        <button
+                          className="inline-flex items-center justify-center rounded-full border border-red-700 bg-transparent px-3 py-1.5 text-xs font-semibold text-red-700 transition hover:bg-red-100"
+                          onClick={() => onDelete(row)}
+                          type="button"
+                        >
+                          {t('ui.delete')}
+                        </button>
+                      )}
+                    </div>
                   </td>
                 )}
               </tr>

--- a/track-app/src/locales/ca/common.json
+++ b/track-app/src/locales/ca/common.json
@@ -55,7 +55,8 @@
     "languageEnglish": "Anglès",
     "languageSpanish": "Espanyol",
     "languageCatalan": "Català",
-    "optional": "opcional"
+    "optional": "opcional",
+    "edit": "Editar"
   },
   "roles": {
     "staff": "staff",

--- a/track-app/src/locales/en/common.json
+++ b/track-app/src/locales/en/common.json
@@ -55,7 +55,8 @@
     "languageEnglish": "English",
     "languageSpanish": "Spanish",
     "languageCatalan": "Catalan",
-    "optional": "optional"
+    "optional": "optional",
+    "edit": "Edit"
   },
   "roles": {
     "staff": "staff",

--- a/track-app/src/locales/es/common.json
+++ b/track-app/src/locales/es/common.json
@@ -55,7 +55,8 @@
     "languageEnglish": "Inglés",
     "languageSpanish": "Español",
     "languageCatalan": "Catalán",
-    "optional": "opcional"
+    "optional": "opcional",
+    "edit": "Editar"
   },
   "roles": {
     "staff": "staff",


### PR DESCRIPTION
## Resumen
- sustituye el backoffice basado en tabs por secciones enrutables
- añade rutas `/backoffice/companies`, `/backoffice/users`, `/backoffice/trackers`
- habilita detalle por id para edición: `/backoffice/companies/:id` y `/backoffice/users/:id`
- adapta el navbar para modo backoffice con navegación contextual
- añade acción `Editar` en tablas (DataTable) y claves i18n asociadas

## Validación
- `npm run typecheck`
- diagnósticos TS sin errores en archivos modificados

## Notas
- `/backoffice` redirige a `/backoffice/companies`
- `/backoffice/trackers/:id` redirige a `/backoffice/trackers` (no hay edición por id)