### PR TITLE
Backoffice tracker detail + emojis persistentes en trackers y POIs

### DIFF
--- a/track-api/src/backoffice/backoffice.repository.js
+++ b/track-api/src/backoffice/backoffice.repository.js
@@ -62,5 +62,27 @@ module.exports = {
 
     async createTracker(data) {
         return Tracker.create(data)
+    },
+
+    async findTrackerById(id) {
+        if (!mongoose.Types.ObjectId.isValid(id)) return null
+        return Tracker.findById(id)
+    },
+
+    async listTrackers(companyId, { offset = 0, limit } = {}) {
+        const query = companyId ? { companyId } : {}
+        const result = Tracker.find(query).sort({ createdAt: -1 }).skip(offset)
+        if (typeof limit === 'number') result.limit(limit)
+        return result.lean()
+    },
+
+    async countTrackers(companyId) {
+        const query = companyId ? { companyId } : {}
+        return Tracker.countDocuments(query)
+    },
+
+    async updateTrackerById(id, patch) {
+        if (!mongoose.Types.ObjectId.isValid(id)) return null
+        return Tracker.findByIdAndUpdate(id, { $set: patch }, { new: true })
     }
 }

--- a/track-api/src/backoffice/backoffice.service.js
+++ b/track-api/src/backoffice/backoffice.service.js
@@ -3,6 +3,7 @@ const { validate, errors: { InputError, LogicError } } = require('track-utils')
 const repo = require('./backoffice.repository')
 const { requireAccess } = require('../shared/authorization.service')
 const { ACCESS_VERSION, encodePermissionKeys, encodeFeatureKeys, PERMISSION_KEYS, FEATURE_KEYS } = require('../shared/access-control')
+const { normalizeTrackerEmoji } = require('../shared/emoji-catalog')
 
 const VALID_ROLES = new Set(['staff', 'owner', 'admin', 'dispatcher', 'viewer'])
 const VALID_LANGUAGES = new Set(['en', 'es', 'ca'])
@@ -136,6 +137,36 @@ const backofficeService = {
         return repo.countUsers(companyId)
     },
 
+    async listTrackers(requesterId, companyId = null, pagination) {
+        await requireAccess(requesterId, { feature: 'backoffice', permission: 'companies.read' })
+        if (companyId) {
+            validate.arguments([{ name: 'companyId', value: companyId, type: String, notEmpty: true }])
+            const company = await repo.findCompanyById(companyId)
+            if (!company) throw new LogicError(`company with id ${companyId} doesn't exists`)
+        }
+        if (!pagination) return repo.listTrackers(companyId)
+        const _pagination = this.normalizePagination(pagination.offset, pagination.limit)
+        return repo.listTrackers(companyId, _pagination)
+    },
+
+    async countTrackers(requesterId, companyId = null) {
+        await requireAccess(requesterId, { feature: 'backoffice', permission: 'companies.read' })
+        if (companyId) {
+            validate.arguments([{ name: 'companyId', value: companyId, type: String, notEmpty: true }])
+            const company = await repo.findCompanyById(companyId)
+            if (!company) throw new LogicError(`company with id ${companyId} doesn't exists`)
+        }
+        return repo.countTrackers(companyId)
+    },
+
+    async retrieveTracker(requesterId, trackerId) {
+        await requireAccess(requesterId, { feature: 'backoffice', permission: 'companies.read' })
+        validate.arguments([{ name: 'trackerId', value: trackerId, type: String, notEmpty: true }])
+        const tracker = await repo.findTrackerById(trackerId)
+        if (!tracker) throw new LogicError(`tracker with id ${trackerId} doesn't exists`)
+        return tracker
+    },
+
     async createUser(requesterId, { name, surname, email, password, role, companyId, language = 'en', permissionKeys } = {}) {
         await requireAccess(requesterId, { feature: 'backoffice', permission: 'users.create' })
         validate.arguments([
@@ -175,7 +206,7 @@ const backofficeService = {
         })
     },
 
-    async createTracker(requesterId, { serialNumber, alias, companyId } = {}) {
+    async createTracker(requesterId, { serialNumber, alias, emoji, companyId } = {}) {
         await requireAccess(requesterId, { feature: 'backoffice', permission: 'companies.update' })
         validate.arguments([
             { name: 'serialNumber', value: serialNumber, type: String, notEmpty: true },
@@ -189,6 +220,7 @@ const backofficeService = {
         validate.arguments([
             { name: 'alias', value: resolvedAlias, type: String, notEmpty: true }
         ])
+        const normalizedEmoji = normalizeTrackerEmoji(emoji)
 
         const company = await repo.findCompanyById(companyId)
         if (!company) throw new LogicError(`company with id ${companyId} doesn't exists`)
@@ -204,8 +236,29 @@ const backofficeService = {
         return repo.createTracker({
             companyId,
             serialNumber,
-            alias: resolvedAlias
+            alias: resolvedAlias,
+            emoji: normalizedEmoji
         })
+    },
+
+    async updateTrackerAlias(requesterId, trackerId, alias) {
+        await requireAccess(requesterId, { feature: 'backoffice', permission: 'companies.update' })
+        validate.arguments([
+            { name: 'trackerId', value: trackerId, type: String, notEmpty: true },
+            { name: 'alias', value: alias, type: String, notEmpty: true }
+        ])
+
+        const tracker = await repo.findTrackerById(trackerId)
+        if (!tracker) throw new LogicError(`tracker with id ${trackerId} doesn't exists`)
+
+        if (alias[0] !== '#') {
+            const aliasTracker = await repo.findTrackerByAlias(alias)
+            if (aliasTracker && aliasTracker._id.toString() !== trackerId) {
+                throw new LogicError(`Alias ${alias} already registered`)
+            }
+        }
+
+        return repo.updateTrackerById(trackerId, { alias })
     },
 
     async updateUser(requesterId, userId, { name, surname, email, language, role, companyId, permissionKeys } = {}) {

--- a/track-api/src/fleet/fleet.repository.js
+++ b/track-api/src/fleet/fleet.repository.js
@@ -59,7 +59,8 @@ module.exports = {
             await Tracker.create({
                 companyId,
                 serialNumber: tracker.serialNumber,
-                alias: tracker.alias || `#MIG-${tracker.serialNumber}`
+                alias: tracker.alias || `#MIG-${tracker.serialNumber}`,
+                emoji: tracker.emoji || '🚚'
             })
         }
     },

--- a/track-api/src/fleet/fleet.service.js
+++ b/track-api/src/fleet/fleet.service.js
@@ -2,6 +2,7 @@ const { errors: { LogicError, InputError } } = require('track-utils')
 const { validate } = require('track-utils')
 const repo = require('./fleet.repository')
 const { ensureUserCompany } = require('../shared/company-context')
+const { normalizeTrackerEmoji } = require('../shared/emoji-catalog')
 
 const fleetService = {
     normalizePagination(offset = 0, limit = 20) {
@@ -13,7 +14,7 @@ const fleetService = {
     addTracker(id, trackerData) {
         if (!trackerData) throw new InputError('incorrect tracker info')
 
-        let { serialNumber, alias } = trackerData
+        let { serialNumber, alias, emoji } = trackerData
         if (!alias || (typeof alias === 'string' && !alias.trim())) {
             alias = '#IS-' + (Math.floor(Math.random() * (9999 - 1000)) + 1000).toString() + '-FAKE'
         }
@@ -21,8 +22,11 @@ const fleetService = {
         validate.arguments([
             { name: 'id', value: id, type: String, notEmpty: true },
             { name: 'serialNumber', value: serialNumber, type: String, notEmpty: true },
-            { name: 'alias', value: alias, type: String, notEmpty: true, optional: true }
+            { name: 'alias', value: alias, type: String, notEmpty: true, optional: true },
+            { name: 'emoji', value: emoji, type: String, notEmpty: true, optional: true }
         ])
+
+        const normalizedEmoji = normalizeTrackerEmoji(emoji)
 
         return (async () => {
             const user = await repo.findUserById(id)
@@ -37,8 +41,8 @@ const fleetService = {
             const serial = await repo.findTrackerBySerial(serialNumber)
             if (serial) throw new LogicError(`Serial Number ${serialNumber} already registered`)
 
-            await repo.createTracker({ companyId, serialNumber, alias })
-            user.trackers.push({ serialNumber, alias })
+            await repo.createTracker({ companyId, serialNumber, alias, emoji: normalizedEmoji })
+            user.trackers.push({ serialNumber, alias, emoji: normalizedEmoji })
             await repo.saveUser(user)
         })()
     },
@@ -165,15 +169,19 @@ const fleetService = {
                 }
             }
 
+            const normalizedEmoji = normalizeTrackerEmoji(trackerData.emoji || tracker.emoji || '🚚')
+
             await repo.updateTrackerByIdAndCompany(tracker._id, companyId, {
                 serialNumber: trackerData.serialNumber || tracker.serialNumber,
-                alias: trackerData.alias || tracker.alias
+                alias: trackerData.alias || tracker.alias,
+                emoji: normalizedEmoji
             })
 
             const legacy = user.trackers.id(trackerID) || user.trackers.find(item => item.serialNumber === tracker.serialNumber)
             if (legacy) {
                 legacy.serialNumber = trackerData.serialNumber || legacy.serialNumber
                 legacy.alias = trackerData.alias || legacy.alias
+                legacy.emoji = normalizedEmoji
                 await repo.saveUser(user)
             }
         })()

--- a/track-api/src/fleet/fleet.service.spec.js
+++ b/track-api/src/fleet/fleet.service.spec.js
@@ -54,6 +54,20 @@ describe('fleetService', () => {
             const pos = resp.trackers.length - 1
             expect(resp.trackers[pos].serialNumber).toBe('1234567890')
             expect(resp.trackers[pos].alias).toBeDefined()
+            expect(resp.trackers[pos].emoji).toBe('🚚')
+        })
+
+        it('should succeed on allowed tracker emoji', async () => {
+            const trackerData = { serialNumber: '1234567890', alias: '1234-ABC', emoji: '🚲' }
+            await service.addTracker(user.id, trackerData)
+            const resp = await User.findById(user.id)
+            const pos = resp.trackers.length - 1
+            expect(resp.trackers[pos].emoji).toBe('🚲')
+        })
+
+        it('should fail on invalid tracker emoji', async () => {
+            const trackerData = { serialNumber: '1234567890', alias: '1234-ABC', emoji: '🛸' }
+            await expectServiceError(() => service.addTracker(user.id, trackerData), InputError, 'invalid tracker emoji 🛸')
         })
 
         it('should fail on incorrect id user', async () => {
@@ -258,6 +272,18 @@ describe('fleetService', () => {
             const data = await User.findById(user.id)
             expect(data.trackers[0].serialNumber).toBe('1234567890')
             expect(data.trackers[0].alias).toBe('0909-UPDATE')
+        })
+
+        it('should succeed on valid tracker emoji update', async () => {
+            const _trackerData = { emoji: '🚌' }
+            await service.updateTracker(user.id, user.trackers[0].id, _trackerData)
+            const data = await User.findById(user.id)
+            expect(data.trackers[0].emoji).toBe('🚌')
+        })
+
+        it('should fail on invalid tracker emoji update', async () => {
+            const _trackerData = { emoji: '🛸' }
+            await expectServiceError(() => service.updateTracker(user.id, user.trackers[0].id, _trackerData), InputError, 'invalid tracker emoji 🛸')
         })
 
         it('should fail on incorrect user id', async () => {

--- a/track-api/src/graphql/resolvers/backoffice.resolver.js
+++ b/track-api/src/graphql/resolvers/backoffice.resolver.js
@@ -36,6 +36,18 @@ function mapUser(user) {
   }
 }
 
+/**
+ * @param {{ _id: { toString: () => string }, serialNumber: string, alias?: string|null, emoji?: string|null }} tracker
+ */
+function mapTracker(tracker) {
+  return {
+    id: tracker._id.toString(),
+    serialNumber: tracker.serialNumber,
+    alias: tracker.alias || null,
+    emoji: tracker.emoji || '🚚'
+  }
+}
+
 const backofficeResolver = {
   Query: {
     /**
@@ -72,6 +84,43 @@ const backofficeResolver = {
           items: rows.map(mapUser),
           totalCount: Number(totalCount || 0)
         }
+      } catch (err) {
+        throw toGraphQLError(/** @type {Error} */ (err))
+      }
+    },
+
+    /**
+     * @param {unknown} _
+     * @param {{ companyId?: string|null, offset?: number, limit?: number }} args
+     * @param {{ userId: string|null }} ctx
+     */
+    async backofficeTrackers(_, { companyId, offset, limit }, ctx) {
+      const userId = requireAuth(ctx)
+      try {
+        const [result, totalCount] = await Promise.all([
+          service.listTrackers(userId, /** @type {any} */ (companyId), { offset, limit }),
+          service.countTrackers(userId, /** @type {any} */ (companyId))
+        ])
+        const rows = /** @type {any[]} */ (Array.isArray(result) ? result : [])
+        return {
+          items: rows.map(mapTracker),
+          totalCount: Number(totalCount || 0)
+        }
+      } catch (err) {
+        throw toGraphQLError(/** @type {Error} */ (err))
+      }
+    },
+
+    /**
+     * @param {unknown} _
+     * @param {{ id: string }} args
+     * @param {{ userId: string|null }} ctx
+     */
+    async backofficeTracker(_, { id }, ctx) {
+      const userId = requireAuth(ctx)
+      try {
+        const tracker = await service.retrieveTracker(userId, id)
+        return mapTracker(tracker)
       } catch (err) {
         throw toGraphQLError(/** @type {Error} */ (err))
       }
@@ -126,7 +175,7 @@ const backofficeResolver = {
 
     /**
      * @param {unknown} _
-     * @param {{ input: { serialNumber: string, alias?: string, companyId: string } }} args
+     * @param {{ input: { serialNumber: string, alias?: string, emoji?: string, companyId: string } }} args
      * @param {{ userId: string|null }} ctx
      */
     async backofficeCreateTracker(_, { input }, ctx) {
@@ -149,6 +198,21 @@ const backofficeResolver = {
       try {
         await service.updateUser(userId, id, input)
         return { success: true, message: 'Ok, user updated.' }
+      } catch (err) {
+        throw toGraphQLError(/** @type {Error} */ (err))
+      }
+    },
+
+    /**
+     * @param {unknown} _
+     * @param {{ id: string, alias: string }} args
+     * @param {{ userId: string|null }} ctx
+     */
+    async backofficeUpdateTrackerAlias(_, { id, alias }, ctx) {
+      const userId = requireAuth(ctx)
+      try {
+        await service.updateTrackerAlias(userId, id, alias)
+        return { success: true, message: 'Ok, tracker alias updated.' }
       } catch (err) {
         throw toGraphQLError(/** @type {Error} */ (err))
       }

--- a/track-api/src/graphql/resolvers/fleet.resolver.js
+++ b/track-api/src/graphql/resolvers/fleet.resolver.js
@@ -23,7 +23,8 @@ const fleetResolver = {
           items: rows.map(t => ({
             id: t._id.toString(),
             serialNumber: t.serialNumber,
-            alias: t.alias || null
+            alias: t.alias || null,
+            emoji: t.emoji || '🚚'
           })),
           totalCount: Number(totalCount || 0)
         }
@@ -42,7 +43,7 @@ const fleetResolver = {
       try {
         await requireAccess(userId, { feature: 'fleet', permission: 'fleet.read' })
         const t = await service.retrieveTracker(userId, id)
-        return { id: t._id.toString(), serialNumber: t.serialNumber, alias: t.alias || null }
+        return { id: t._id.toString(), serialNumber: t.serialNumber, alias: t.alias || null, emoji: t.emoji || '🚚' }
       } catch (err) {
         throw toGraphQLError(/** @type {Error} */ (err))
       }
@@ -58,7 +59,7 @@ const fleetResolver = {
       try {
         await requireAccess(userId, { feature: 'fleet', permission: 'fleet.read' })
         const t = await service.retrieveTrackerBySN(userId, serialNumber)
-        return { id: t._id.toString(), serialNumber: t.serialNumber, alias: t.alias || null }
+        return { id: t._id.toString(), serialNumber: t.serialNumber, alias: t.alias || null, emoji: t.emoji || '🚚' }
       } catch (err) {
         throw toGraphQLError(/** @type {Error} */ (err))
       }
@@ -74,7 +75,7 @@ const fleetResolver = {
       try {
         await requireAccess(userId, { feature: 'fleet', permission: 'fleet.read' })
         const t = await service.retrieveTrackerByAlias(userId, alias)
-        return { id: t._id.toString(), serialNumber: t.serialNumber, alias: t.alias || null }
+        return { id: t._id.toString(), serialNumber: t.serialNumber, alias: t.alias || null, emoji: t.emoji || '🚚' }
       } catch (err) {
         throw toGraphQLError(/** @type {Error} */ (err))
       }

--- a/track-api/src/graphql/resolvers/poi.resolver.js
+++ b/track-api/src/graphql/resolvers/poi.resolver.js
@@ -24,6 +24,7 @@ const poiResolver = {
             id: p._id.toString(),
             title: p.title,
             color: p.color,
+            emoji: p.emoji || '📍',
             latitude: p.latitude,
             longitude: p.longitude
           })),
@@ -44,7 +45,7 @@ const poiResolver = {
       try {
         await requireAccess(userId, { feature: 'poi', permission: 'poi.read' })
         const p = await service.retrieveOnePOI(userId, id)
-        return { id: p._id.toString(), title: p.title, color: p.color, latitude: p.latitude, longitude: p.longitude }
+        return { id: p._id.toString(), title: p.title, color: p.color, emoji: p.emoji || '📍', latitude: p.latitude, longitude: p.longitude }
       } catch (err) {
         throw toGraphQLError(err)
       }

--- a/track-api/src/graphql/schema.graphql
+++ b/track-api/src/graphql/schema.graphql
@@ -50,6 +50,7 @@ type Tracker {
   id: ID!
   serialNumber: String!
   alias: String
+  emoji: String
 }
 
 type Track {
@@ -76,6 +77,7 @@ type POI {
   id: ID!
   title: String!
   color: String!
+  emoji: String
   latitude: Float!
   longitude: Float!
 }
@@ -144,22 +146,26 @@ input BackofficeUpdateUserInput {
 input BackofficeCreateTrackerInput {
   serialNumber: String!
   alias: String
+  emoji: String
   companyId: ID!
 }
 
 input AddTrackerInput {
   serialNumber: String!
   alias: String
+  emoji: String
 }
 
 input UpdateTrackerInput {
   serialNumber: String
   alias: String
+  emoji: String
 }
 
 input AddPOIInput {
   title: String!
   color: String!
+  emoji: String
   latitude: Float!
   longitude: Float!
 }
@@ -167,6 +173,7 @@ input AddPOIInput {
 input UpdatePOIInput {
   title: String
   color: String
+  emoji: String
   latitude: Float
   longitude: Float
 }
@@ -188,6 +195,12 @@ type Query {
     offset: Int = 0
     limit: Int = 20
   ): PagedBackofficeUsers!
+  backofficeTrackers(
+    companyId: ID
+    offset: Int = 0
+    limit: Int = 20
+  ): PagedTrackers!
+  backofficeTracker(id: ID!): Tracker!
 }
 
 type Mutation {
@@ -208,6 +221,7 @@ type Mutation {
   ): MutationResult!
   backofficeCreateUser(input: BackofficeCreateUserInput!): MutationResult!
   backofficeCreateTracker(input: BackofficeCreateTrackerInput!): MutationResult!
+  backofficeUpdateTrackerAlias(id: ID!, alias: String!): MutationResult!
   backofficeUpdateUser(
     id: ID!
     input: BackofficeUpdateUserInput!

--- a/track-api/src/poi/poi.repository.js
+++ b/track-api/src/poi/poi.repository.js
@@ -49,6 +49,7 @@ module.exports = {
                 companyId,
                 title: poi.title || 'Migrated POI',
                 color: poi.color || '#89c800',
+                emoji: poi.emoji || '📍',
                 latitude: poi.latitude,
                 longitude: poi.longitude
             })

--- a/track-api/src/poi/poi.service.js
+++ b/track-api/src/poi/poi.service.js
@@ -2,6 +2,7 @@ const { errors: { LogicError, InputError } } = require('track-utils')
 const { validate } = require('track-utils')
 const repo = require('./poi.repository')
 const { ensureUserCompany } = require('../shared/company-context')
+const { normalizePoiEmoji } = require('../shared/emoji-catalog')
 
 const poiService = {
     normalizePagination(offset = 0, limit = 20) {
@@ -13,18 +14,20 @@ const poiService = {
     addPOI(id, poiData) {
         if (!poiData) throw new InputError('incorrect poi info')
 
-        let { title, color, latitude, longitude } = poiData
+        let { title, color, emoji, latitude, longitude } = poiData
 
         validate.arguments([
             { name: 'id', value: id, type: String, notEmpty: true },
             { name: 'title', value: title, type: String, notEmpty: true, optional: true },
             { name: 'color', value: color, type: String, notEmpty: true, optional: true },
+            { name: 'emoji', value: emoji, type: String, notEmpty: true, optional: true },
             { name: 'latitude', value: latitude, type: Number, notEmpty: true },
             { name: 'longitude', value: longitude, type: Number, notEmpty: true }
         ])
 
         title ? title = title : title = 'Kripton-' + ((Math.random() * 1000).toFixed(0)).toString()
         color ? color = color : color = '#89c800'
+        emoji = normalizePoiEmoji(emoji)
 
         return (async () => {
             const user = await repo.findUserById(id)
@@ -32,8 +35,8 @@ const poiService = {
             const companyId = await ensureUserCompany(user)
             await repo.syncLegacyPois(companyId, user.pois || [])
 
-            await repo.createPOI({ companyId, title, color, latitude, longitude })
-            user.pois.push({ title, color, latitude, longitude })
+            await repo.createPOI({ companyId, title, color, emoji, latitude, longitude })
+            user.pois.push({ title, color, emoji, latitude, longitude })
             await repo.saveUser(user)
         })()
     },
@@ -116,12 +119,14 @@ const poiService = {
             await repo.updateByIdAndCompany(poi._id || poiID, companyId, {
                 title: poiData.title || poi.title,
                 color: poiData.color || poi.color,
+                emoji: normalizePoiEmoji(poiData.emoji || poi.emoji || '📍'),
                 latitude: poiData.latitude || poi.latitude,
                 longitude: poiData.longitude || poi.longitude
             })
             if (legacyPoi) {
                 legacyPoi.title = poiData.title || legacyPoi.title
                 legacyPoi.color = poiData.color || legacyPoi.color
+                legacyPoi.emoji = normalizePoiEmoji(poiData.emoji || legacyPoi.emoji || '📍')
                 legacyPoi.latitude = poiData.latitude || legacyPoi.latitude
                 legacyPoi.longitude = poiData.longitude || legacyPoi.longitude
                 await repo.saveUser(user)

--- a/track-api/src/poi/poi.service.spec.js
+++ b/track-api/src/poi/poi.service.spec.js
@@ -82,6 +82,24 @@ describe('poiService', () => {
             const pos = resp.pois.length - 1
             expect(resp.pois[pos].title).toBeDefined()
             expect(resp.pois[pos].color).toBe('#89c800')
+            expect(resp.pois[pos].emoji).toBe('📍')
+        })
+
+        it('should succeed on allowed poi emoji', async () => {
+            const lat = Math.random() * 100
+            const lon = Math.random() * 10
+            const poiData = { title: 'My Fav', color: '#ff0000', emoji: '🏭', latitude: lat, longitude: lon }
+            await service.addPOI(user.id, poiData)
+            const resp = await User.findById(user.id)
+            const pos = resp.pois.length - 1
+            expect(resp.pois[pos].emoji).toBe('🏭')
+        })
+
+        it('should fail on invalid poi emoji', async () => {
+            const lat = Math.random() * 100
+            const lon = Math.random() * 10
+            const poiData = { title: 'My Fav', color: '#ff0000', emoji: '🛸', latitude: lat, longitude: lon }
+            await expectServiceError(() => service.addPOI(user.id, poiData), InputError, 'invalid poi emoji 🛸')
         })
 
         it('should fail on incorrect id user', async () => {
@@ -212,6 +230,16 @@ describe('poiService', () => {
             const data = await User.findById(user.id)
             expect(data.pois[0].title).toBe('Your UPDATED Fav')
             expect(data.pois[0].color).toBe('#ff0000')
+        })
+
+        it('should succeed on valid poi emoji update', async () => {
+            await service.updatePOI(user.id, user.pois[0].id, { emoji: '🏢' })
+            const data = await User.findById(user.id)
+            expect(data.pois[0].emoji).toBe('🏢')
+        })
+
+        it('should fail on invalid poi emoji update', async () => {
+            await expectServiceError(() => service.updatePOI(user.id, user.pois[0].id, { emoji: '🛸' }), InputError, 'invalid poi emoji 🛸')
         })
 
         it('should fail on incorrect user id', async () => {

--- a/track-api/src/shared/emoji-catalog.js
+++ b/track-api/src/shared/emoji-catalog.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const { errors: { InputError } } = require('track-utils')
+
+const TRACKER_EMOJIS = new Set([
+    '🚚',
+    '🚛',
+    '🚗',
+    '🚕',
+    '🚌',
+    '🚎',
+    '🏍️',
+    '🚲',
+    '🚐'
+])
+
+const POI_EMOJIS = new Set([
+    '📍',
+    '🏢',
+    '🏭',
+    '🏬',
+    '🏪',
+    '🏥',
+    '🏫',
+    '🏦',
+    '⛽',
+    '🏠'
+])
+
+function normalizeTrackerEmoji(emoji) {
+    if (!emoji) return '🚚'
+    if (!TRACKER_EMOJIS.has(emoji)) throw new InputError(`invalid tracker emoji ${emoji}`)
+    return emoji
+}
+
+function normalizePoiEmoji(emoji) {
+    if (!emoji) return '📍'
+    if (!POI_EMOJIS.has(emoji)) throw new InputError(`invalid poi emoji ${emoji}`)
+    return emoji
+}
+
+module.exports = {
+    TRACKER_EMOJIS,
+    POI_EMOJIS,
+    normalizeTrackerEmoji,
+    normalizePoiEmoji
+}

--- a/track-api/src/shared/emoji-catalog.spec.js
+++ b/track-api/src/shared/emoji-catalog.spec.js
@@ -1,0 +1,37 @@
+const { errors: { InputError } } = require('track-utils')
+const {
+    normalizeTrackerEmoji,
+    normalizePoiEmoji
+} = require('./emoji-catalog')
+
+describe('emoji catalog', () => {
+    describe('normalizeTrackerEmoji', () => {
+        it('returns default emoji when value is missing', () => {
+            expect(normalizeTrackerEmoji(undefined)).toBe('🚚')
+            expect(normalizeTrackerEmoji('')).toBe('🚚')
+        })
+
+        it('returns value when emoji is allowed', () => {
+            expect(normalizeTrackerEmoji('🚲')).toBe('🚲')
+        })
+
+        it('throws InputError when tracker emoji is invalid', () => {
+            expect(() => normalizeTrackerEmoji('🛸')).toThrow(InputError)
+        })
+    })
+
+    describe('normalizePoiEmoji', () => {
+        it('returns default emoji when value is missing', () => {
+            expect(normalizePoiEmoji(undefined)).toBe('📍')
+            expect(normalizePoiEmoji('')).toBe('📍')
+        })
+
+        it('returns value when emoji is allowed', () => {
+            expect(normalizePoiEmoji('🏢')).toBe('🏢')
+        })
+
+        it('throws InputError when poi emoji is invalid', () => {
+            expect(() => normalizePoiEmoji('🛸')).toThrow(InputError)
+        })
+    })
+})

--- a/track-app/src/common/emoji-options.ts
+++ b/track-app/src/common/emoji-options.ts
@@ -1,0 +1,24 @@
+export const TRACKER_EMOJIS = [
+  { value: '🚚', label: 'Camion' },
+  { value: '🚛', label: 'Trailer' },
+  { value: '🚗', label: 'Coche' },
+  { value: '🚕', label: 'Taxi' },
+  { value: '🚌', label: 'Autobus' },
+  { value: '🚎', label: 'Trolebus' },
+  { value: '🏍️', label: 'Moto' },
+  { value: '🚲', label: 'Bici' },
+  { value: '🚐', label: 'Furgoneta' }
+] as const
+
+export const POI_EMOJIS = [
+  { value: '📍', label: 'Pin' },
+  { value: '🏢', label: 'Oficina' },
+  { value: '🏭', label: 'Fabrica' },
+  { value: '🏬', label: 'Centro comercial' },
+  { value: '🏪', label: 'Tienda' },
+  { value: '🏥', label: 'Hospital' },
+  { value: '🏫', label: 'Escuela' },
+  { value: '🏦', label: 'Banco' },
+  { value: '⛽', label: 'Gasolinera' },
+  { value: '🏠', label: 'Casa' }
+] as const

--- a/track-app/src/components/App.tsx
+++ b/track-app/src/components/App.tsx
@@ -11,6 +11,7 @@ import TrackingsNew from './Trackings/New'
 import TrackingDetail from './TrackingDetail'
 import Places from './Places'
 import PlacesNew from './Places/New'
+import PlacesEdit from './Places/Edit'
 import Backoffice from './Backoffice'
 import { onSessionExpired } from '../apollo/session'
 import Navbar from './Navbar'
@@ -53,6 +54,8 @@ interface BackofficeRouteProps {
   canReadUsers: boolean
   canCreateUsers: boolean
   canUpdateUsers: boolean
+  canReadTrackers: boolean
+  canUpdateTrackers: boolean
   canCreateTrackers: boolean
 }
 
@@ -60,12 +63,13 @@ function BackofficeRoute({
   canReadUsers,
   canCreateUsers,
   canUpdateUsers,
+  canReadTrackers,
+  canUpdateTrackers,
   canCreateTrackers
 }: BackofficeRouteProps) {
   const { section, entityId } = useParams<{ section: string, entityId?: string }>()
   const normalizedSection = normalizeBackofficeSection(section)
   if (section !== normalizedSection) return <Navigate to="/backoffice/companies" replace />
-  if (normalizedSection === 'trackers' && entityId) return <Navigate to="/backoffice/trackers" replace />
 
   return (
     <Backoffice
@@ -74,6 +78,8 @@ function BackofficeRoute({
       canReadUsers={canReadUsers}
       canCreateUsers={canCreateUsers}
       canUpdateUsers={canUpdateUsers}
+      canReadTrackers={canReadTrackers}
+      canUpdateTrackers={canUpdateTrackers}
       canCreateTrackers={canCreateTrackers}
     />
   )
@@ -109,9 +115,23 @@ function App() {
     meData?.me?.featureKeys?.includes('backoffice') &&
     meData?.me?.permissionKeys?.includes('fleet.create')
   )
+  const canReadTrackers = Boolean(
+    meData?.me?.featureKeys?.includes('backoffice') &&
+    meData?.me?.permissionKeys?.includes('fleet.read')
+  )
+  const canUpdateTrackers = Boolean(
+    meData?.me?.featureKeys?.includes('backoffice') &&
+    meData?.me?.permissionKeys?.includes('fleet.update')
+  )
   const canAccessBackoffice = Boolean(
     meData?.me?.featureKeys?.includes('backoffice') &&
-    (meData?.me?.permissionKeys?.includes('companies.read') || meData?.me?.permissionKeys?.includes('users.read'))
+    (
+      meData?.me?.permissionKeys?.includes('companies.read') ||
+      meData?.me?.permissionKeys?.includes('users.read') ||
+      meData?.me?.permissionKeys?.includes('fleet.read') ||
+      meData?.me?.permissionKeys?.includes('fleet.create') ||
+      meData?.me?.permissionKeys?.includes('fleet.update')
+    )
   )
 
   // ── Session expiry handler ────────────────────────────────────────────────
@@ -176,7 +196,7 @@ function App() {
           onBackofficeUsers={handleBackofficeUsers}
           onBackofficeTrackers={handleBackofficeTrackers}
           showBackofficeUsers={canReadUsers || canCreateUsers || canUpdateUsers}
-          showBackofficeTrackers={canCreateTrackers}
+          showBackofficeTrackers={canReadTrackers || canUpdateTrackers || canCreateTrackers}
           onLogout={handleLogout}
         />
       )}
@@ -195,6 +215,7 @@ function App() {
 
         <Route path="/places"     element={guard(<Places />)} />
         <Route path="/places/new" element={guard(<PlacesNew />)} />
+        <Route path="/places/:poiId" element={guard(<PlacesEdit />)} />
 
         <Route path="/trackers"     element={guard(<Trackings />)} />
         <Route path="/trackers/new" element={guard(<TrackingsNew />)} />
@@ -206,6 +227,8 @@ function App() {
               canReadUsers={canReadUsers}
               canCreateUsers={canCreateUsers}
               canUpdateUsers={canUpdateUsers}
+              canReadTrackers={canReadTrackers}
+              canUpdateTrackers={canUpdateTrackers}
               canCreateTrackers={canCreateTrackers}
             />
           )}
@@ -217,6 +240,8 @@ function App() {
               canReadUsers={canReadUsers}
               canCreateUsers={canCreateUsers}
               canUpdateUsers={canUpdateUsers}
+              canReadTrackers={canReadTrackers}
+              canUpdateTrackers={canUpdateTrackers}
               canCreateTrackers={canCreateTrackers}
             />
           )}

--- a/track-app/src/components/Backoffice/index.tsx
+++ b/track-app/src/components/Backoffice/index.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import PageShell from '../shared/PageShell'
 import DataTable, { Column } from '../shared/DataTable'
-import { useBackoffice, BackofficeCompany, BackofficeUser } from '../../hooks/useBackoffice'
+import { useBackoffice, BackofficeCompany, BackofficeTracker, BackofficeUser } from '../../hooks/useBackoffice'
 import { FEATURE_KEYS, PERMISSION_KEYS, permissionTemplateForRole } from './access-catalog'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
+import { TRACKER_EMOJIS } from '../../common/emoji-options'
 
 function toggleInArray(list: string[], value: string): string[] {
   return list.includes(value)
@@ -18,6 +19,8 @@ interface BackofficeProps {
   canReadUsers?: boolean
   canCreateUsers?: boolean
   canUpdateUsers?: boolean
+  canReadTrackers?: boolean
+  canUpdateTrackers?: boolean
   canCreateTrackers?: boolean
 }
 
@@ -27,6 +30,8 @@ function Backoffice({
   canReadUsers = true,
   canCreateUsers = true,
   canUpdateUsers = true,
+  canReadTrackers = true,
+  canUpdateTrackers = true,
   canCreateTrackers = true
 }: BackofficeProps) {
   const { t } = useTranslation()
@@ -42,10 +47,27 @@ function Backoffice({
   const isUsersSection = section === 'users'
   const isTrackersSection = section === 'trackers'
   const canSeeUsersSection = canReadUsers || canCreateUsers || canUpdateUsers
+  const canSeeTrackersSection = canReadTrackers || canUpdateTrackers || canCreateTrackers
   const shouldLoadUsers = isUsersSection && canReadUsers
+  const shouldLoadTrackers = isTrackersSection && canReadTrackers
 
   const [usersPage, setUsersPage] = useState(1)
-  const { companies, users, usersTotalCount, loading, createCompany, createUser, createTracker, updateCompany, updateUser } = useBackoffice(usersPage, 20, shouldLoadUsers)
+  const [trackersPage, setTrackersPage] = useState(1)
+  const {
+    companies,
+    users,
+    trackers,
+    trackerDetail,
+    usersTotalCount,
+    trackersTotalCount,
+    loading,
+    createCompany,
+    createUser,
+    createTracker,
+    updateCompany,
+    updateUser,
+    updateTrackerAlias
+  } = useBackoffice(usersPage, 20, shouldLoadUsers, trackersPage, 20, shouldLoadTrackers, isTrackersSection ? entityId : undefined)
   const [companyForm, setCompanyForm] = useState({
     name: '',
     active: true,
@@ -64,10 +86,12 @@ function Backoffice({
   const [trackerForm, setTrackerForm] = useState({
     serialNumber: '',
     alias: '',
+    emoji: '🚚',
     companyId: ''
   })
   const [selectedCompanyId, setSelectedCompanyId] = useState<string>('')
   const [selectedUserId, setSelectedUserId] = useState<string>('')
+  const [trackerAliasEdit, setTrackerAliasEdit] = useState('')
   const COMPANY_COLUMNS: Column<BackofficeCompany>[] = [
     { key: 'name', label: t('auth.name') },
     { key: 'slug', label: t('backoffice.slug') },
@@ -94,6 +118,15 @@ function Backoffice({
       label: t('backoffice.permissions'),
       render: (row) => row.permissionKeys.join(', ')
     }
+  ]
+  const TRACKER_COLUMNS: Column<BackofficeTracker>[] = [
+    {
+      key: 'emoji',
+      label: t('ui.emoji'),
+      render: (row) => row.emoji || '🚚'
+    },
+    { key: 'serialNumber', label: t('trackers.serialNumber') },
+    { key: 'alias', label: t('ui.alias') }
   ]
 
   const companyOptions = useMemo(
@@ -140,11 +173,13 @@ function Backoffice({
     await createTracker({
       serialNumber: trackerForm.serialNumber,
       alias: trackerForm.alias || undefined,
+      emoji: trackerForm.emoji,
       companyId: trackerForm.companyId
     })
     setTrackerForm({
       serialNumber: '',
       alias: '',
+      emoji: '🚚',
       companyId: ''
     })
   }
@@ -236,6 +271,11 @@ function Backoffice({
       permissionKeys: userEdit.permissionKeys
     })
   }
+  const onUpdateTrackerAlias = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!trackerDetail?.id || !trackerAliasEdit.trim()) return
+    await updateTrackerAlias(trackerDetail.id, trackerAliasEdit.trim())
+  }
 
   useEffect(() => {
     if (!isCompaniesSection) return
@@ -250,6 +290,11 @@ function Backoffice({
     if (nextUserId !== selectedUserId) setSelectedUserId(nextUserId)
     if (nextUserId) fillUserEdit(nextUserId)
   }, [isUsersSection, entityId, selectedUserId, users])
+
+  useEffect(() => {
+    if (!isTrackersSection) return
+    setTrackerAliasEdit(trackerDetail?.alias || '')
+  }, [isTrackersSection, trackerDetail?.id, trackerDetail?.alias])
 
   return (
     <PageShell title={t('backoffice.title')}>
@@ -272,7 +317,7 @@ function Backoffice({
             {t('backoffice.users')}
           </button>
         )}
-        {canCreateTrackers && (
+        {canSeeTrackersSection && (
           <button
             className={`rounded-full border px-3 py-1.5 text-sm font-medium ${isTrackersSection ? 'bg-[var(--bg-glass-strong)] text-[var(--text-primary)]' : 'bg-[var(--bg-glass)] text-[var(--text-secondary)]'}`}
             onClick={() => navigate('/backoffice/trackers')}
@@ -590,7 +635,19 @@ function Backoffice({
                 placeholder={t('ui.optional')}
               />
             </div>
-            <div className="md:col-span-2">
+            <div>
+              <label className={labelClass}>{t('ui.emoji')}</label>
+              <select
+                className={inputClass}
+                value={trackerForm.emoji}
+                onChange={(e) => setTrackerForm(prev => ({ ...prev, emoji: e.target.value }))}
+              >
+                {TRACKER_EMOJIS.map((option) => (
+                  <option key={option.value} value={option.value}>{option.value} {option.label}</option>
+                ))}
+              </select>
+            </div>
+            <div>
               <label className={labelClass}>{t('backoffice.company')}</label>
               <select
                 className={inputClass}
@@ -606,6 +663,57 @@ function Backoffice({
             </div>
           </div>
           <button className={`${primaryButtonClass} mt-6`} type="submit">{t('backoffice.createTracker')}</button>
+        </form>
+      </section>
+      )}
+
+      {isTrackersSection && canReadTrackers && (
+      <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
+        <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('trackers.title')}</h3>
+        <DataTable
+          columns={TRACKER_COLUMNS}
+          rows={trackers}
+          emptyMessage={t('trackers.empty')}
+          variant="flat"
+          onEdit={(tracker) => navigate(`/backoffice/trackers/${tracker.id}`)}
+          pageSize={20}
+          serverPagination={{
+            enabled: true,
+            currentPage: trackersPage,
+            totalCount: trackersTotalCount,
+            onPageChange: setTrackersPage
+          }}
+        />
+      </section>
+      )}
+
+      {isTrackersSection && canReadTrackers && trackerDetail && (
+      <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
+        <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.editTrackerAlias')}</h3>
+        <form onSubmit={onUpdateTrackerAlias}>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div>
+              <label className={labelClass}>{t('trackers.serialNumber')}</label>
+              <input className={inputClass} value={trackerDetail.serialNumber} readOnly />
+            </div>
+            <div>
+              <label className={labelClass}>{t('ui.emoji')}</label>
+              <input className={inputClass} value={trackerDetail.emoji || '🚚'} readOnly />
+            </div>
+            <div className="md:col-span-2">
+              <label className={labelClass}>{t('ui.alias')}</label>
+              <input
+                className={inputClass}
+                value={trackerAliasEdit}
+                onChange={(e) => setTrackerAliasEdit(e.target.value)}
+                required
+                readOnly={!canUpdateTrackers}
+              />
+            </div>
+          </div>
+          {canUpdateTrackers && (
+            <button className={`${primaryButtonClass} mt-6`} type="submit">{t('backoffice.updateTrackerAlias')}</button>
+          )}
         </form>
       </section>
       )}

--- a/track-app/src/components/Home/index.tsx
+++ b/track-app/src/components/Home/index.tsx
@@ -58,9 +58,9 @@ function Home({ darkmode }: HomeProps) {
     items.forEach(poi => {
       const poiIcon = L.divIcon({
         className: '',
-        html: `<div style="background:${poi.color || '#3b82f6'};width:24px;height:24px;border-radius:50%;border:2px solid white;box-shadow:0 1px 3px rgba(0,0,0,0.4);"></div>`,
-        iconSize: [24, 24],
-        iconAnchor: [12, 12]
+        html: `<div style="background:${poi.color || '#3b82f6'};width:28px;height:28px;border-radius:50%;border:2px solid white;box-shadow:0 1px 3px rgba(0,0,0,0.4);display:flex;align-items:center;justify-content:center;font-size:16px;">${poi.emoji || '📍'}</div>`,
+        iconSize: [28, 28],
+        iconAnchor: [14, 14]
       })
       const marker = L.marker([poi.latitude, poi.longitude], { icon: poiIcon })
       const popupHtml = `
@@ -89,11 +89,11 @@ function Home({ darkmode }: HomeProps) {
     })
   }
 
-  const makeTruckIcon = (status?: string | null) => {
+  const makeTruckIcon = (status?: string | null, emoji?: string | null) => {
     const bgColor = status === 'ON' ? '#22c55e' : '#ef4444'
     return L.divIcon({
       className: '',
-      html: `<div style="background:${bgColor};width:30px;height:30px;border-radius:50%;border:2px solid white;box-shadow:0 1px 3px rgba(0,0,0,0.4);display:flex;align-items:center;justify-content:center;font-size:16px;">🚚</div>`,
+      html: `<div style="background:${bgColor};width:30px;height:30px;border-radius:50%;border:2px solid white;box-shadow:0 1px 3px rgba(0,0,0,0.4);display:flex;align-items:center;justify-content:center;font-size:16px;">${emoji || '🚚'}</div>`,
       iconSize: [30, 30],
       iconAnchor: [15, 15]
     })
@@ -140,6 +140,7 @@ function Home({ darkmode }: HomeProps) {
       const freshness = 'date' in truck ? telemetryFreshness(truck.date) : { label: 'STALE', color: '#f59e0b' }
       const sn = truck.serialNumber
       const alias = truck.alias || aliasBySerial.get(sn) || sn
+      const trackerEmoji = trackers.find(item => item.serialNumber === sn)?.emoji || '🚚'
       const popupSignature = `${alias}|${status || ''}|${speed.toFixed(2)}|${freshness.label}`
       const popupHtml = `
         <div class="tracker-popup">
@@ -167,7 +168,7 @@ function Home({ darkmode }: HomeProps) {
         const prevSignature = truckPopupSignatureRef.current.get(sn)
         // Only rewrite popup/icon when visible popup data changed.
         if (prevSignature !== popupSignature) {
-          existing.setIcon(makeTruckIcon(status))
+          existing.setIcon(makeTruckIcon(status, trackerEmoji))
           if (existing.isPopupOpen()) {
             existing.setPopupContent(popupHtml)
             // Leaflet recreates popup DOM when content changes; rebind actions immediately.
@@ -188,7 +189,7 @@ function Home({ darkmode }: HomeProps) {
       } else {
         // First time seeing this truck — create marker
         const marker = L.marker([lat, lng], {
-          icon: makeTruckIcon(status),
+          icon: makeTruckIcon(status, trackerEmoji),
           title: `${t('home.sn')}: ${sn} - ${t('home.speed')}: ${speed} Km/h`
         })
         marker.bindPopup(popupHtml, {

--- a/track-app/src/components/Places/Edit.tsx
+++ b/track-app/src/components/Places/Edit.tsx
@@ -1,0 +1,112 @@
+import React, { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import PageShell from '../shared/PageShell'
+import { useGetPoiQuery, useUpdatePoiMutation } from '../../generated/graphql'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'react-toastify'
+import { POI_EMOJIS } from '../../common/emoji-options'
+
+function PlacesEdit() {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const { poiId } = useParams<{ poiId: string }>()
+  const [form, setForm] = useState({
+    title: '',
+    latitude: '',
+    longitude: '',
+    color: 'blue',
+    emoji: '📍'
+  })
+
+  const { data, loading } = useGetPoiQuery({
+    skip: !poiId,
+    variables: { id: poiId || '' }
+  })
+  const [updatePoi, { loading: updating }] = useUpdatePoiMutation({
+    onCompleted: (res) => {
+      toast.success(res.updatePOI.message)
+      navigate('/places')
+    },
+    onError: (err) => toast.error(err.message)
+  })
+
+  useEffect(() => {
+    const poi = data?.poi
+    if (!poi) return
+    setForm({
+      title: poi.title,
+      latitude: String(poi.latitude),
+      longitude: String(poi.longitude),
+      color: poi.color,
+      emoji: poi.emoji || '📍'
+    })
+  }, [data?.poi])
+
+  const labelClass = 'mb-2 block text-sm font-semibold'
+  const inputClass = 'glass-input-base w-full rounded-full border px-4 py-2 text-sm outline-none transition'
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    if (!poiId) return
+    await updatePoi({
+      variables: {
+        id: poiId,
+        input: {
+          title: form.title,
+          latitude: parseFloat(form.latitude),
+          longitude: parseFloat(form.longitude),
+          color: form.color,
+          emoji: form.emoji
+        }
+      }
+    })
+  }
+
+  return (
+    <PageShell title={t('places.editPoi')} backTo="/places">
+      {loading && <p className="text-center text-[var(--text-muted)]">{t('ui.loading')}</p>}
+      {!loading && (
+        <form onSubmit={handleSubmit} className="mx-auto max-w-[420px] space-y-4">
+          <div>
+            <label className={labelClass}>{t('ui.title')}</label>
+            <input className={inputClass} value={form.title} onChange={(e) => setForm(prev => ({ ...prev, title: e.target.value }))} required />
+          </div>
+          <div>
+            <label className={labelClass}>{t('ui.latitude')}</label>
+            <input className={inputClass} type="number" step="any" value={form.latitude} onChange={(e) => setForm(prev => ({ ...prev, latitude: e.target.value }))} required />
+          </div>
+          <div>
+            <label className={labelClass}>{t('ui.longitude')}</label>
+            <input className={inputClass} type="number" step="any" value={form.longitude} onChange={(e) => setForm(prev => ({ ...prev, longitude: e.target.value }))} required />
+          </div>
+          <div>
+            <label className={labelClass}>{t('ui.emoji')}</label>
+            <select className={inputClass} value={form.emoji} onChange={(e) => setForm(prev => ({ ...prev, emoji: e.target.value }))}>
+              {POI_EMOJIS.map((option) => (
+                <option key={option.value} value={option.value}>{option.value} {option.label}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className={labelClass}>{t('places.markerColor')}</label>
+            <select className={inputClass} value={form.color} onChange={(e) => setForm(prev => ({ ...prev, color: e.target.value }))}>
+              <option value="blue">{t('places.colors.blue')}</option>
+              <option value="lightblue">{t('places.colors.lightblue')}</option>
+              <option value="orange">{t('places.colors.orange')}</option>
+              <option value="purple">{t('places.colors.purple')}</option>
+              <option value="red">{t('places.colors.red')}</option>
+              <option value="yellow">{t('places.colors.yellow')}</option>
+            </select>
+          </div>
+          <div className="pt-2">
+            <button className="w-full rounded-full border border-amber-500 bg-amber-400 px-4 py-2 font-semibold text-slate-800 transition hover:brightness-105 disabled:opacity-60" disabled={updating} type="submit">
+              {t('places.updatePoi')}
+            </button>
+          </div>
+        </form>
+      )}
+    </PageShell>
+  )
+}
+
+export default PlacesEdit

--- a/track-app/src/components/Places/New.tsx
+++ b/track-app/src/components/Places/New.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PageShell from '../shared/PageShell'
 import { useAddPOI } from '../../hooks/useAddPOI'
 import { useTranslation } from 'react-i18next'
+import { POI_EMOJIS } from '../../common/emoji-options'
 
 function PlacesNew() {
   const { t } = useTranslation()
@@ -16,7 +17,8 @@ function PlacesNew() {
     const latitude = parseFloat((form.elements.namedItem('latitude') as HTMLInputElement).value)
     const longitude = parseFloat((form.elements.namedItem('longitude') as HTMLInputElement).value)
     const color = (form.elements.namedItem('color') as HTMLSelectElement).value
-    addPOI({ title, color, latitude, longitude })
+    const emoji = (form.elements.namedItem('emoji') as HTMLSelectElement).value
+    addPOI({ title, color, emoji, latitude, longitude })
     form.reset()
   }
 
@@ -57,6 +59,15 @@ function PlacesNew() {
             step="any"
             required
           />
+        </div>
+
+        <div>
+          <label className={labelClass}>{t('ui.emoji')}</label>
+          <select name="emoji" defaultValue="📍" className={inputClass}>
+            {POI_EMOJIS.map((option) => (
+              <option key={option.value} value={option.value}>{option.value} {option.label}</option>
+            ))}
+          </select>
         </div>
 
         <div>

--- a/track-app/src/components/Places/index.tsx
+++ b/track-app/src/components/Places/index.tsx
@@ -12,6 +12,11 @@ function Places() {
   const { pois, totalCount, loading, deletePOI } = usePOIs(page, 20)
 
   const POI_COLUMNS: Column<Poi>[] = [
+    {
+      key: 'emoji',
+      label: t('ui.emoji'),
+      render: (row) => row.emoji || '📍'
+    },
     { key: 'title', label: t('ui.title') },
     { key: 'latitude', label: t('ui.latitude') },
     { key: 'longitude', label: t('ui.longitude') },
@@ -47,6 +52,7 @@ function Places() {
         : <DataTable
             columns={POI_COLUMNS}
             rows={pois}
+            onEdit={(poi) => navigate(`/places/${poi.id}`)}
             onDelete={handleDelete}
             emptyMessage={t('places.empty')}
             pageSize={20}

--- a/track-app/src/components/Trackings/New.tsx
+++ b/track-app/src/components/Trackings/New.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PageShell from '../shared/PageShell'
 import { useAddTracker } from '../../hooks/useAddTracker'
 import { useTranslation } from 'react-i18next'
+import { TRACKER_EMOJIS } from '../../common/emoji-options'
 
 function TrackingsNew() {
   const { t } = useTranslation()
@@ -14,7 +15,8 @@ function TrackingsNew() {
     const form = e.currentTarget
     const serialNumber = (form.elements.namedItem('serialNumber') as HTMLInputElement).value
     const alias = (form.elements.namedItem('alias') as HTMLInputElement).value
-    addTracker({ serialNumber, alias: alias || null })
+    const emoji = (form.elements.namedItem('emoji') as HTMLSelectElement).value
+    addTracker({ serialNumber, alias: alias || null, emoji })
     form.reset()
   }
 
@@ -31,6 +33,15 @@ function TrackingsNew() {
             autoFocus
             required
           />
+        </div>
+
+        <div>
+          <label className={labelClass}>{t('ui.emoji')}</label>
+          <select name="emoji" defaultValue="🚚" className={inputClass}>
+            {TRACKER_EMOJIS.map((option) => (
+              <option key={option.value} value={option.value}>{option.value} {option.label}</option>
+            ))}
+          </select>
         </div>
 
         <div>

--- a/track-app/src/components/Trackings/index.tsx
+++ b/track-app/src/components/Trackings/index.tsx
@@ -44,6 +44,11 @@ function Trackings() {
         />
       )
     },
+    {
+      key: 'emoji',
+      label: t('ui.emoji'),
+      render: (row) => <span>{row.emoji || '🚚'}</span>
+    },
     { key: 'alias', label: t('ui.alias') },
     { key: 'serialNumber', label: t('ui.serial') },
     {

--- a/track-app/src/generated/graphql.ts
+++ b/track-app/src/generated/graphql.ts
@@ -25,6 +25,7 @@ export type Scalars = {
 
 export type AddPoiInput = {
   color: Scalars['String']['input'];
+  emoji?: InputMaybe<Scalars['String']['input']>;
   latitude: Scalars['Float']['input'];
   longitude: Scalars['Float']['input'];
   title: Scalars['String']['input'];
@@ -32,6 +33,7 @@ export type AddPoiInput = {
 
 export type AddTrackerInput = {
   alias?: InputMaybe<Scalars['String']['input']>;
+  emoji?: InputMaybe<Scalars['String']['input']>;
   serialNumber: Scalars['String']['input'];
 };
 
@@ -50,6 +52,7 @@ export type BackofficeCreateCompanyInput = {
 export type BackofficeCreateTrackerInput = {
   alias?: InputMaybe<Scalars['String']['input']>;
   companyId: Scalars['ID']['input'];
+  emoji?: InputMaybe<Scalars['String']['input']>;
   serialNumber: Scalars['String']['input'];
 };
 
@@ -121,6 +124,7 @@ export type Mutation = {
   backofficeCreateTracker: MutationResult;
   backofficeCreateUser: MutationResult;
   backofficeUpdateCompany: MutationResult;
+  backofficeUpdateTrackerAlias: MutationResult;
   backofficeUpdateUser: MutationResult;
   deletePOI: MutationResult;
   deleteTracker: MutationResult;
@@ -161,6 +165,12 @@ export type MutationBackofficeCreateUserArgs = {
 export type MutationBackofficeUpdateCompanyArgs = {
   id: Scalars['ID']['input'];
   input: BackofficeUpdateCompanyInput;
+};
+
+
+export type MutationBackofficeUpdateTrackerAliasArgs = {
+  alias: Scalars['String']['input'];
+  id: Scalars['ID']['input'];
 };
 
 
@@ -216,6 +226,7 @@ export type MutationResult = {
 export type Poi = {
   __typename?: 'POI';
   color: Scalars['String']['output'];
+  emoji?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   latitude: Scalars['Float']['output'];
   longitude: Scalars['Float']['output'];
@@ -243,6 +254,8 @@ export type PagedTrackers = {
 export type Query = {
   __typename?: 'Query';
   backofficeCompanies: Array<Company>;
+  backofficeTracker: Tracker;
+  backofficeTrackers: PagedTrackers;
   backofficeUsers: PagedBackofficeUsers;
   lastTrack?: Maybe<Track>;
   lastTracks: Array<LiveTrack>;
@@ -254,6 +267,18 @@ export type Query = {
   trackerByAlias: Tracker;
   trackerBySN: Tracker;
   trackers: PagedTrackers;
+};
+
+
+export type QueryBackofficeTrackerArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type QueryBackofficeTrackersArgs = {
+  companyId?: InputMaybe<Scalars['ID']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -334,12 +359,14 @@ export type Track = {
 export type Tracker = {
   __typename?: 'Tracker';
   alias?: Maybe<Scalars['String']['output']>;
+  emoji?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   serialNumber: Scalars['String']['output'];
 };
 
 export type UpdatePoiInput = {
   color?: InputMaybe<Scalars['String']['input']>;
+  emoji?: InputMaybe<Scalars['String']['input']>;
   latitude?: InputMaybe<Scalars['Float']['input']>;
   longitude?: InputMaybe<Scalars['Float']['input']>;
   title?: InputMaybe<Scalars['String']['input']>;
@@ -347,6 +374,7 @@ export type UpdatePoiInput = {
 
 export type UpdateTrackerInput = {
   alias?: InputMaybe<Scalars['String']['input']>;
+  emoji?: InputMaybe<Scalars['String']['input']>;
   serialNumber?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -415,6 +443,30 @@ export type BackofficeCreateTrackerMutationVariables = Exact<{
 
 export type BackofficeCreateTrackerMutation = { __typename?: 'Mutation', backofficeCreateTracker: { __typename?: 'MutationResult', success: boolean, message: string } };
 
+export type BackofficeTrackersQueryVariables = Exact<{
+  companyId?: InputMaybe<Scalars['ID']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+}>;
+
+
+export type BackofficeTrackersQuery = { __typename?: 'Query', backofficeTrackers: { __typename?: 'PagedTrackers', totalCount: number, items: Array<{ __typename?: 'Tracker', id: string, serialNumber: string, alias?: string | null, emoji?: string | null }> } };
+
+export type BackofficeTrackerQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type BackofficeTrackerQuery = { __typename?: 'Query', backofficeTracker: { __typename?: 'Tracker', id: string, serialNumber: string, alias?: string | null, emoji?: string | null } };
+
+export type BackofficeUpdateTrackerAliasMutationVariables = Exact<{
+  id: Scalars['ID']['input'];
+  alias: Scalars['String']['input'];
+}>;
+
+
+export type BackofficeUpdateTrackerAliasMutation = { __typename?: 'Mutation', backofficeUpdateTrackerAlias: { __typename?: 'MutationResult', success: boolean, message: string } };
+
 export type BackofficeUpdateUserMutationVariables = Exact<{
   id: Scalars['ID']['input'];
   input: BackofficeUpdateUserInput;
@@ -429,14 +481,21 @@ export type GetTrackersQueryVariables = Exact<{
 }>;
 
 
-export type GetTrackersQuery = { __typename?: 'Query', trackers: { __typename?: 'PagedTrackers', totalCount: number, items: Array<{ __typename?: 'Tracker', id: string, serialNumber: string, alias?: string | null }> } };
+export type GetTrackersQuery = { __typename?: 'Query', trackers: { __typename?: 'PagedTrackers', totalCount: number, items: Array<{ __typename?: 'Tracker', id: string, serialNumber: string, alias?: string | null, emoji?: string | null }> } };
+
+export type TrackerQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type TrackerQuery = { __typename?: 'Query', tracker: { __typename?: 'Tracker', id: string, serialNumber: string, alias?: string | null, emoji?: string | null } };
 
 export type TrackerBySnQueryVariables = Exact<{
   serialNumber: Scalars['String']['input'];
 }>;
 
 
-export type TrackerBySnQuery = { __typename?: 'Query', trackerBySN: { __typename?: 'Tracker', id: string, serialNumber: string, alias?: string | null } };
+export type TrackerBySnQuery = { __typename?: 'Query', trackerBySN: { __typename?: 'Tracker', id: string, serialNumber: string, alias?: string | null, emoji?: string | null } };
 
 export type AddTrackerMutationVariables = Exact<{
   input: AddTrackerInput;
@@ -498,7 +557,14 @@ export type GetPoIsQueryVariables = Exact<{
 }>;
 
 
-export type GetPoIsQuery = { __typename?: 'Query', pois: { __typename?: 'PagedPOIs', totalCount: number, items: Array<{ __typename?: 'POI', id: string, title: string, color: string, latitude: number, longitude: number }> } };
+export type GetPoIsQuery = { __typename?: 'Query', pois: { __typename?: 'PagedPOIs', totalCount: number, items: Array<{ __typename?: 'POI', id: string, title: string, color: string, emoji?: string | null, latitude: number, longitude: number }> } };
+
+export type GetPoiQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type GetPoiQuery = { __typename?: 'Query', poi: { __typename?: 'POI', id: string, title: string, color: string, emoji?: string | null, latitude: number, longitude: number } };
 
 export type AddPoiMutationVariables = Exact<{
   input: AddPoiInput;
@@ -506,6 +572,14 @@ export type AddPoiMutationVariables = Exact<{
 
 
 export type AddPoiMutation = { __typename?: 'Mutation', addPOI: { __typename?: 'MutationResult', success: boolean, message: string } };
+
+export type UpdatePoiMutationVariables = Exact<{
+  id: Scalars['ID']['input'];
+  input: UpdatePoiInput;
+}>;
+
+
+export type UpdatePoiMutation = { __typename?: 'Mutation', updatePOI: { __typename?: 'MutationResult', success: boolean, message: string } };
 
 export type DeletePoiMutationVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -772,6 +846,138 @@ export function useBackofficeCreateTrackerMutation(baseOptions?: Apollo.Mutation
 export type BackofficeCreateTrackerMutationHookResult = ReturnType<typeof useBackofficeCreateTrackerMutation>;
 export type BackofficeCreateTrackerMutationResult = Apollo.MutationResult<BackofficeCreateTrackerMutation>;
 export type BackofficeCreateTrackerMutationOptions = Apollo.BaseMutationOptions<BackofficeCreateTrackerMutation, BackofficeCreateTrackerMutationVariables>;
+export const BackofficeTrackersDocument = gql`
+    query BackofficeTrackers($companyId: ID, $offset: Int = 0, $limit: Int = 20) {
+  backofficeTrackers(companyId: $companyId, offset: $offset, limit: $limit) {
+    totalCount
+    items {
+      id
+      serialNumber
+      alias
+      emoji
+    }
+  }
+}
+    `;
+
+/**
+ * __useBackofficeTrackersQuery__
+ *
+ * To run a query within a React component, call `useBackofficeTrackersQuery` and pass it any options that fit your needs.
+ * When your component renders, `useBackofficeTrackersQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useBackofficeTrackersQuery({
+ *   variables: {
+ *      companyId: // value for 'companyId'
+ *      offset: // value for 'offset'
+ *      limit: // value for 'limit'
+ *   },
+ * });
+ */
+export function useBackofficeTrackersQuery(baseOptions?: Apollo.QueryHookOptions<BackofficeTrackersQuery, BackofficeTrackersQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<BackofficeTrackersQuery, BackofficeTrackersQueryVariables>(BackofficeTrackersDocument, options);
+      }
+export function useBackofficeTrackersLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<BackofficeTrackersQuery, BackofficeTrackersQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<BackofficeTrackersQuery, BackofficeTrackersQueryVariables>(BackofficeTrackersDocument, options);
+        }
+// @ts-ignore
+export function useBackofficeTrackersSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<BackofficeTrackersQuery, BackofficeTrackersQueryVariables>): Apollo.UseSuspenseQueryResult<BackofficeTrackersQuery, BackofficeTrackersQueryVariables>;
+export function useBackofficeTrackersSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<BackofficeTrackersQuery, BackofficeTrackersQueryVariables>): Apollo.UseSuspenseQueryResult<BackofficeTrackersQuery | undefined, BackofficeTrackersQueryVariables>;
+export function useBackofficeTrackersSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<BackofficeTrackersQuery, BackofficeTrackersQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<BackofficeTrackersQuery, BackofficeTrackersQueryVariables>(BackofficeTrackersDocument, options);
+        }
+export type BackofficeTrackersQueryHookResult = ReturnType<typeof useBackofficeTrackersQuery>;
+export type BackofficeTrackersLazyQueryHookResult = ReturnType<typeof useBackofficeTrackersLazyQuery>;
+export type BackofficeTrackersSuspenseQueryHookResult = ReturnType<typeof useBackofficeTrackersSuspenseQuery>;
+export type BackofficeTrackersQueryResult = Apollo.QueryResult<BackofficeTrackersQuery, BackofficeTrackersQueryVariables>;
+export const BackofficeTrackerDocument = gql`
+    query BackofficeTracker($id: ID!) {
+  backofficeTracker(id: $id) {
+    id
+    serialNumber
+    alias
+    emoji
+  }
+}
+    `;
+
+/**
+ * __useBackofficeTrackerQuery__
+ *
+ * To run a query within a React component, call `useBackofficeTrackerQuery` and pass it any options that fit your needs.
+ * When your component renders, `useBackofficeTrackerQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useBackofficeTrackerQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useBackofficeTrackerQuery(baseOptions: Apollo.QueryHookOptions<BackofficeTrackerQuery, BackofficeTrackerQueryVariables> & ({ variables: BackofficeTrackerQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<BackofficeTrackerQuery, BackofficeTrackerQueryVariables>(BackofficeTrackerDocument, options);
+      }
+export function useBackofficeTrackerLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<BackofficeTrackerQuery, BackofficeTrackerQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<BackofficeTrackerQuery, BackofficeTrackerQueryVariables>(BackofficeTrackerDocument, options);
+        }
+// @ts-ignore
+export function useBackofficeTrackerSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<BackofficeTrackerQuery, BackofficeTrackerQueryVariables>): Apollo.UseSuspenseQueryResult<BackofficeTrackerQuery, BackofficeTrackerQueryVariables>;
+export function useBackofficeTrackerSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<BackofficeTrackerQuery, BackofficeTrackerQueryVariables>): Apollo.UseSuspenseQueryResult<BackofficeTrackerQuery | undefined, BackofficeTrackerQueryVariables>;
+export function useBackofficeTrackerSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<BackofficeTrackerQuery, BackofficeTrackerQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<BackofficeTrackerQuery, BackofficeTrackerQueryVariables>(BackofficeTrackerDocument, options);
+        }
+export type BackofficeTrackerQueryHookResult = ReturnType<typeof useBackofficeTrackerQuery>;
+export type BackofficeTrackerLazyQueryHookResult = ReturnType<typeof useBackofficeTrackerLazyQuery>;
+export type BackofficeTrackerSuspenseQueryHookResult = ReturnType<typeof useBackofficeTrackerSuspenseQuery>;
+export type BackofficeTrackerQueryResult = Apollo.QueryResult<BackofficeTrackerQuery, BackofficeTrackerQueryVariables>;
+export const BackofficeUpdateTrackerAliasDocument = gql`
+    mutation BackofficeUpdateTrackerAlias($id: ID!, $alias: String!) {
+  backofficeUpdateTrackerAlias(id: $id, alias: $alias) {
+    success
+    message
+  }
+}
+    `;
+export type BackofficeUpdateTrackerAliasMutationFn = Apollo.MutationFunction<BackofficeUpdateTrackerAliasMutation, BackofficeUpdateTrackerAliasMutationVariables>;
+
+/**
+ * __useBackofficeUpdateTrackerAliasMutation__
+ *
+ * To run a mutation, you first call `useBackofficeUpdateTrackerAliasMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useBackofficeUpdateTrackerAliasMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [backofficeUpdateTrackerAliasMutation, { data, loading, error }] = useBackofficeUpdateTrackerAliasMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *      alias: // value for 'alias'
+ *   },
+ * });
+ */
+export function useBackofficeUpdateTrackerAliasMutation(baseOptions?: Apollo.MutationHookOptions<BackofficeUpdateTrackerAliasMutation, BackofficeUpdateTrackerAliasMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<BackofficeUpdateTrackerAliasMutation, BackofficeUpdateTrackerAliasMutationVariables>(BackofficeUpdateTrackerAliasDocument, options);
+      }
+export type BackofficeUpdateTrackerAliasMutationHookResult = ReturnType<typeof useBackofficeUpdateTrackerAliasMutation>;
+export type BackofficeUpdateTrackerAliasMutationResult = Apollo.MutationResult<BackofficeUpdateTrackerAliasMutation>;
+export type BackofficeUpdateTrackerAliasMutationOptions = Apollo.BaseMutationOptions<BackofficeUpdateTrackerAliasMutation, BackofficeUpdateTrackerAliasMutationVariables>;
 export const BackofficeUpdateUserDocument = gql`
     mutation BackofficeUpdateUser($id: ID!, $input: BackofficeUpdateUserInput!) {
   backofficeUpdateUser(id: $id, input: $input) {
@@ -815,6 +1021,7 @@ export const GetTrackersDocument = gql`
       id
       serialNumber
       alias
+      emoji
     }
   }
 }
@@ -856,12 +1063,59 @@ export type GetTrackersQueryHookResult = ReturnType<typeof useGetTrackersQuery>;
 export type GetTrackersLazyQueryHookResult = ReturnType<typeof useGetTrackersLazyQuery>;
 export type GetTrackersSuspenseQueryHookResult = ReturnType<typeof useGetTrackersSuspenseQuery>;
 export type GetTrackersQueryResult = Apollo.QueryResult<GetTrackersQuery, GetTrackersQueryVariables>;
+export const TrackerDocument = gql`
+    query Tracker($id: ID!) {
+  tracker(id: $id) {
+    id
+    serialNumber
+    alias
+    emoji
+  }
+}
+    `;
+
+/**
+ * __useTrackerQuery__
+ *
+ * To run a query within a React component, call `useTrackerQuery` and pass it any options that fit your needs.
+ * When your component renders, `useTrackerQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useTrackerQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useTrackerQuery(baseOptions: Apollo.QueryHookOptions<TrackerQuery, TrackerQueryVariables> & ({ variables: TrackerQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<TrackerQuery, TrackerQueryVariables>(TrackerDocument, options);
+      }
+export function useTrackerLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TrackerQuery, TrackerQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<TrackerQuery, TrackerQueryVariables>(TrackerDocument, options);
+        }
+// @ts-ignore
+export function useTrackerSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<TrackerQuery, TrackerQueryVariables>): Apollo.UseSuspenseQueryResult<TrackerQuery, TrackerQueryVariables>;
+export function useTrackerSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<TrackerQuery, TrackerQueryVariables>): Apollo.UseSuspenseQueryResult<TrackerQuery | undefined, TrackerQueryVariables>;
+export function useTrackerSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<TrackerQuery, TrackerQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<TrackerQuery, TrackerQueryVariables>(TrackerDocument, options);
+        }
+export type TrackerQueryHookResult = ReturnType<typeof useTrackerQuery>;
+export type TrackerLazyQueryHookResult = ReturnType<typeof useTrackerLazyQuery>;
+export type TrackerSuspenseQueryHookResult = ReturnType<typeof useTrackerSuspenseQuery>;
+export type TrackerQueryResult = Apollo.QueryResult<TrackerQuery, TrackerQueryVariables>;
 export const TrackerBySnDocument = gql`
     query TrackerBySN($serialNumber: String!) {
   trackerBySN(serialNumber: $serialNumber) {
     id
     serialNumber
     alias
+    emoji
   }
 }
     `;
@@ -1197,6 +1451,7 @@ export const GetPoIsDocument = gql`
       id
       title
       color
+      emoji
       latitude
       longitude
     }
@@ -1240,6 +1495,54 @@ export type GetPoIsQueryHookResult = ReturnType<typeof useGetPoIsQuery>;
 export type GetPoIsLazyQueryHookResult = ReturnType<typeof useGetPoIsLazyQuery>;
 export type GetPoIsSuspenseQueryHookResult = ReturnType<typeof useGetPoIsSuspenseQuery>;
 export type GetPoIsQueryResult = Apollo.QueryResult<GetPoIsQuery, GetPoIsQueryVariables>;
+export const GetPoiDocument = gql`
+    query GetPOI($id: ID!) {
+  poi(id: $id) {
+    id
+    title
+    color
+    emoji
+    latitude
+    longitude
+  }
+}
+    `;
+
+/**
+ * __useGetPoiQuery__
+ *
+ * To run a query within a React component, call `useGetPoiQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetPoiQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetPoiQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useGetPoiQuery(baseOptions: Apollo.QueryHookOptions<GetPoiQuery, GetPoiQueryVariables> & ({ variables: GetPoiQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetPoiQuery, GetPoiQueryVariables>(GetPoiDocument, options);
+      }
+export function useGetPoiLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetPoiQuery, GetPoiQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetPoiQuery, GetPoiQueryVariables>(GetPoiDocument, options);
+        }
+// @ts-ignore
+export function useGetPoiSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<GetPoiQuery, GetPoiQueryVariables>): Apollo.UseSuspenseQueryResult<GetPoiQuery, GetPoiQueryVariables>;
+export function useGetPoiSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetPoiQuery, GetPoiQueryVariables>): Apollo.UseSuspenseQueryResult<GetPoiQuery | undefined, GetPoiQueryVariables>;
+export function useGetPoiSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetPoiQuery, GetPoiQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<GetPoiQuery, GetPoiQueryVariables>(GetPoiDocument, options);
+        }
+export type GetPoiQueryHookResult = ReturnType<typeof useGetPoiQuery>;
+export type GetPoiLazyQueryHookResult = ReturnType<typeof useGetPoiLazyQuery>;
+export type GetPoiSuspenseQueryHookResult = ReturnType<typeof useGetPoiSuspenseQuery>;
+export type GetPoiQueryResult = Apollo.QueryResult<GetPoiQuery, GetPoiQueryVariables>;
 export const AddPoiDocument = gql`
     mutation AddPOI($input: AddPOIInput!) {
   addPOI(input: $input) {
@@ -1274,6 +1577,41 @@ export function useAddPoiMutation(baseOptions?: Apollo.MutationHookOptions<AddPo
 export type AddPoiMutationHookResult = ReturnType<typeof useAddPoiMutation>;
 export type AddPoiMutationResult = Apollo.MutationResult<AddPoiMutation>;
 export type AddPoiMutationOptions = Apollo.BaseMutationOptions<AddPoiMutation, AddPoiMutationVariables>;
+export const UpdatePoiDocument = gql`
+    mutation UpdatePOI($id: ID!, $input: UpdatePOIInput!) {
+  updatePOI(id: $id, input: $input) {
+    success
+    message
+  }
+}
+    `;
+export type UpdatePoiMutationFn = Apollo.MutationFunction<UpdatePoiMutation, UpdatePoiMutationVariables>;
+
+/**
+ * __useUpdatePoiMutation__
+ *
+ * To run a mutation, you first call `useUpdatePoiMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdatePoiMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updatePoiMutation, { data, loading, error }] = useUpdatePoiMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useUpdatePoiMutation(baseOptions?: Apollo.MutationHookOptions<UpdatePoiMutation, UpdatePoiMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdatePoiMutation, UpdatePoiMutationVariables>(UpdatePoiDocument, options);
+      }
+export type UpdatePoiMutationHookResult = ReturnType<typeof useUpdatePoiMutation>;
+export type UpdatePoiMutationResult = Apollo.MutationResult<UpdatePoiMutation>;
+export type UpdatePoiMutationOptions = Apollo.BaseMutationOptions<UpdatePoiMutation, UpdatePoiMutationVariables>;
 export const DeletePoiDocument = gql`
     mutation DeletePOI($id: ID!) {
   deletePOI(id: $id) {

--- a/track-app/src/graphql/backoffice.gql
+++ b/track-app/src/graphql/backoffice.gql
@@ -55,6 +55,34 @@ mutation BackofficeCreateTracker($input: BackofficeCreateTrackerInput!) {
   }
 }
 
+query BackofficeTrackers($companyId: ID, $offset: Int = 0, $limit: Int = 20) {
+  backofficeTrackers(companyId: $companyId, offset: $offset, limit: $limit) {
+    totalCount
+    items {
+      id
+      serialNumber
+      alias
+      emoji
+    }
+  }
+}
+
+query BackofficeTracker($id: ID!) {
+  backofficeTracker(id: $id) {
+    id
+    serialNumber
+    alias
+    emoji
+  }
+}
+
+mutation BackofficeUpdateTrackerAlias($id: ID!, $alias: String!) {
+  backofficeUpdateTrackerAlias(id: $id, alias: $alias) {
+    success
+    message
+  }
+}
+
 mutation BackofficeUpdateUser($id: ID!, $input: BackofficeUpdateUserInput!) {
   backofficeUpdateUser(id: $id, input: $input) {
     success

--- a/track-app/src/graphql/fleet.gql
+++ b/track-app/src/graphql/fleet.gql
@@ -1,11 +1,14 @@
 query GetTrackers($offset: Int = 0, $limit: Int = 20) {
   trackers(offset: $offset, limit: $limit) {
     totalCount
-    items { id serialNumber alias }
+    items { id serialNumber alias emoji }
   }
 }
+query Tracker($id: ID!) {
+  tracker(id: $id) { id serialNumber alias emoji }
+}
 query TrackerBySN($serialNumber: String!) {
-  trackerBySN(serialNumber: $serialNumber) { id serialNumber alias }
+  trackerBySN(serialNumber: $serialNumber) { id serialNumber alias emoji }
 }
 mutation AddTracker($input: AddTrackerInput!) {
   addTracker(input: $input) { success message }

--- a/track-app/src/graphql/poi.gql
+++ b/track-app/src/graphql/poi.gql
@@ -1,11 +1,17 @@
 query GetPOIs($offset: Int = 0, $limit: Int = 20) {
   pois(offset: $offset, limit: $limit) {
     totalCount
-    items { id title color latitude longitude }
+    items { id title color emoji latitude longitude }
   }
+}
+query GetPOI($id: ID!) {
+  poi(id: $id) { id title color emoji latitude longitude }
 }
 mutation AddPOI($input: AddPOIInput!) {
   addPOI(input: $input) { success message }
+}
+mutation UpdatePOI($id: ID!, $input: UpdatePOIInput!) {
+  updatePOI(id: $id, input: $input) { success message }
 }
 mutation DeletePOI($id: ID!) {
   deletePOI(id: $id) { success message }

--- a/track-app/src/hooks/useBackoffice.ts
+++ b/track-app/src/hooks/useBackoffice.ts
@@ -1,12 +1,17 @@
 import { useMemo } from 'react'
 import { toast } from 'react-toastify'
 import {
+    BackofficeTrackerDocument,
+    BackofficeTrackersDocument,
     BackofficeCompaniesDocument,
     BackofficeUsersDocument,
     useBackofficeCompaniesQuery,
+    useBackofficeTrackerQuery,
+    useBackofficeTrackersQuery,
     useBackofficeCreateCompanyMutation,
     useBackofficeCreateTrackerMutation,
     useBackofficeCreateUserMutation,
+    useBackofficeUpdateTrackerAliasMutation,
     useBackofficeUpdateCompanyMutation,
     useBackofficeUpdateUserMutation,
     useBackofficeUsersQuery
@@ -31,8 +36,24 @@ export type BackofficeUser = {
     permissionKeys: string[]
 }
 
-export function useBackoffice(usersPage = 1, pageSize = 20, enableUsersQuery = true) {
+export type BackofficeTracker = {
+    id: string
+    serialNumber: string
+    alias: string | null
+    emoji: string | null
+}
+
+export function useBackoffice(
+    usersPage = 1,
+    pageSize = 20,
+    enableUsersQuery = true,
+    trackersPage = 1,
+    trackersPageSize = 20,
+    enableTrackersQuery = false,
+    trackerId?: string
+) {
     const offset = Math.max(0, (usersPage - 1) * pageSize)
+    const trackersOffset = Math.max(0, (trackersPage - 1) * trackersPageSize)
     const companiesQuery = useBackofficeCompaniesQuery({
         fetchPolicy: 'cache-and-network',
         errorPolicy: 'all',
@@ -43,6 +64,20 @@ export function useBackoffice(usersPage = 1, pageSize = 20, enableUsersQuery = t
         errorPolicy: 'all',
         skip: !enableUsersQuery,
         variables: { offset, limit: pageSize },
+        onError: (err) => toast.error(err.message)
+    })
+    const trackersQuery = useBackofficeTrackersQuery({
+        fetchPolicy: 'cache-and-network',
+        errorPolicy: 'all',
+        skip: !enableTrackersQuery,
+        variables: { offset: trackersOffset, limit: trackersPageSize },
+        onError: (err) => toast.error(err.message)
+    })
+    const trackerDetailQuery = useBackofficeTrackerQuery({
+        fetchPolicy: 'cache-and-network',
+        errorPolicy: 'all',
+        skip: !trackerId,
+        variables: { id: trackerId || '' },
         onError: (err) => toast.error(err.message)
     })
 
@@ -70,6 +105,9 @@ export function useBackoffice(usersPage = 1, pageSize = 20, enableUsersQuery = t
         onError: (err) => toast.error(err.message),
         refetchQueries: [{ query: BackofficeUsersDocument }]
     })
+    const [updateTrackerAliasMutation] = useBackofficeUpdateTrackerAliasMutation({
+        onError: (err) => toast.error(err.message)
+    })
 
     const companies = useMemo<BackofficeCompany[]>(
         () => (companiesQuery.data?.backofficeCompanies ?? []).map(c => ({
@@ -95,6 +133,25 @@ export function useBackoffice(usersPage = 1, pageSize = 20, enableUsersQuery = t
         })),
         [usersQuery.data]
     )
+    const trackers = useMemo<BackofficeTracker[]>(
+        () => (trackersQuery.data?.backofficeTrackers?.items ?? []).map(t => ({
+            id: t.id,
+            serialNumber: t.serialNumber,
+            alias: t.alias ?? null,
+            emoji: t.emoji ?? '🚚'
+        })),
+        [trackersQuery.data]
+    )
+    const trackerDetail = useMemo<BackofficeTracker | null>(() => {
+        const t = trackerDetailQuery.data?.backofficeTracker
+        if (!t) return null
+        return {
+            id: t.id,
+            serialNumber: t.serialNumber,
+            alias: t.alias ?? null,
+            emoji: t.emoji ?? '🚚'
+        }
+    }, [trackerDetailQuery.data])
 
     const createCompany = async (name: string, active: boolean, featureKeys?: string[]) => {
         const res = await createCompanyMutation({ variables: { input: { name, active, featureKeys } } })
@@ -123,6 +180,7 @@ export function useBackoffice(usersPage = 1, pageSize = 20, enableUsersQuery = t
     const createTracker = async (input: {
         serialNumber: string
         alias?: string
+        emoji?: string
         companyId: string
     }) => {
         const res = await createTrackerMutation({ variables: { input } })
@@ -141,16 +199,30 @@ export function useBackoffice(usersPage = 1, pageSize = 20, enableUsersQuery = t
         const res = await updateUserMutation({ variables: { id, input } })
         if (res.data?.backofficeUpdateUser.success) toast.success(res.data.backofficeUpdateUser.message)
     }
+    const updateTrackerAlias = async (id: string, alias: string) => {
+        const res = await updateTrackerAliasMutation({
+            variables: { id, alias },
+            refetchQueries: [
+                { query: BackofficeTrackersDocument },
+                { query: BackofficeTrackerDocument, variables: { id } }
+            ]
+        })
+        if (res.data?.backofficeUpdateTrackerAlias.success) toast.success(res.data.backofficeUpdateTrackerAlias.message)
+    }
 
     return {
         companies,
         users,
+        trackers,
+        trackerDetail,
         usersTotalCount: enableUsersQuery ? (usersQuery.data?.backofficeUsers?.totalCount ?? 0) : 0,
-        loading: companiesQuery.loading || usersQuery.loading,
+        trackersTotalCount: enableTrackersQuery ? (trackersQuery.data?.backofficeTrackers?.totalCount ?? 0) : 0,
+        loading: companiesQuery.loading || usersQuery.loading || trackersQuery.loading || trackerDetailQuery.loading,
         createCompany,
         updateCompany,
         createUser,
         createTracker,
-        updateUser
+        updateUser,
+        updateTrackerAlias
     }
 }

--- a/track-app/src/locales/ca/common.json
+++ b/track-app/src/locales/ca/common.json
@@ -51,6 +51,7 @@
     "latitude": "Latitud",
     "longitude": "Longitud",
     "color": "Color",
+    "emoji": "Emoji",
     "role": "Rol",
     "languageEnglish": "Anglès",
     "languageSpanish": "Espanyol",
@@ -101,8 +102,10 @@
     "title": "Punts d'Interès",
     "newPoiAction": "+ Nou POI",
     "newPoi": "Nou Punt d'Interès",
+    "editPoi": "Editar POI",
     "empty": "Encara no hi ha POIs. Crea el primer!",
     "createPoi": "Crear POI",
+    "updatePoi": "Actualitzar POI",
     "markerColor": "Color del marcador",
     "colors": {
       "blue": "Blau",
@@ -159,6 +162,7 @@
     "editCompany": "Editar companyia",
     "createUser": "Crear usuari",
     "createTracker": "Crear tracker",
+    "editTrackerAlias": "Editar àlies del tracker",
     "editUser": "Editar usuari",
     "users": "Usuaris",
     "active": "Actiu",
@@ -177,7 +181,8 @@
     "noCompanies": "Encara no hi ha companyies.",
     "noUsers": "Encara no hi ha usuaris.",
     "updateCompany": "Actualitzar companyia",
-    "updateUser": "Actualitzar usuari"
+    "updateUser": "Actualitzar usuari",
+    "updateTrackerAlias": "Actualitzar àlies"
   },
   "app": {
     "brandName": "TorToise GPS",

--- a/track-app/src/locales/en/common.json
+++ b/track-app/src/locales/en/common.json
@@ -51,6 +51,7 @@
     "latitude": "Latitude",
     "longitude": "Longitude",
     "color": "Color",
+    "emoji": "Emoji",
     "role": "Role",
     "languageEnglish": "English",
     "languageSpanish": "Spanish",
@@ -101,8 +102,10 @@
     "title": "Points of Interest",
     "newPoiAction": "+ New POI",
     "newPoi": "New Point of Interest",
+    "editPoi": "Edit POI",
     "empty": "No POIs yet. Create your first one!",
     "createPoi": "Create POI",
+    "updatePoi": "Update POI",
     "markerColor": "Marker Color",
     "colors": {
       "blue": "Blue",
@@ -156,6 +159,7 @@
     "usersTab": "Users",
     "createCompany": "Create Company",
     "createTracker": "Create Tracker",
+    "editTrackerAlias": "Edit Tracker Alias",
     "companies": "Companies",
     "editCompany": "Edit Company",
     "createUser": "Create User",
@@ -177,7 +181,8 @@
     "noCompanies": "No companies yet.",
     "noUsers": "No users yet.",
     "updateCompany": "Update Company",
-    "updateUser": "Update User"
+    "updateUser": "Update User",
+    "updateTrackerAlias": "Update Alias"
   },
   "app": {
     "brandName": "TorToise GPS",

--- a/track-app/src/locales/es/common.json
+++ b/track-app/src/locales/es/common.json
@@ -51,6 +51,7 @@
     "latitude": "Latitud",
     "longitude": "Longitud",
     "color": "Color",
+    "emoji": "Emoji",
     "role": "Rol",
     "languageEnglish": "Inglés",
     "languageSpanish": "Español",
@@ -101,8 +102,10 @@
     "title": "Puntos de Interés",
     "newPoiAction": "+ Nuevo POI",
     "newPoi": "Nuevo Punto de Interés",
+    "editPoi": "Editar POI",
     "empty": "Aún no hay POIs. ¡Crea el primero!",
     "createPoi": "Crear POI",
+    "updatePoi": "Actualizar POI",
     "markerColor": "Color del marcador",
     "colors": {
       "blue": "Azul",
@@ -159,6 +162,7 @@
     "editCompany": "Editar compañía",
     "createUser": "Crear usuario",
     "createTracker": "Crear tracker",
+    "editTrackerAlias": "Editar alias del tracker",
     "editUser": "Editar usuario",
     "users": "Usuarios",
     "active": "Activo",
@@ -177,7 +181,8 @@
     "noCompanies": "Aún no hay compañías.",
     "noUsers": "Aún no hay usuarios.",
     "updateCompany": "Actualizar compañía",
-    "updateUser": "Actualizar usuario"
+    "updateUser": "Actualizar usuario",
+    "updateTrackerAlias": "Actualizar alias"
   },
   "app": {
     "brandName": "TorToise GPS",

--- a/track-data/models/schemas/index.js
+++ b/track-data/models/schemas/index.js
@@ -7,7 +7,8 @@ const point = new Schema({
     title: { type: String, required: true },
     latitude: { type: Number, required: true },
     longitude: { type: Number, required: true },
-    color: { type: String, required: true }
+    color: { type: String, required: true },
+    emoji: { type: String }
 })
 
 const TrackSchema = new Schema({
@@ -22,7 +23,8 @@ TrackSchema.index({ serialNumber: 1, date: 1 })
 
 const tracker = new Schema({
     serialNumber: { type: String, required: true, index: true },
-    alias: { type: String }
+    alias: { type: String },
+    emoji: { type: String }
 })
 
 const company = new Schema({
@@ -36,7 +38,8 @@ const company = new Schema({
 const companyTracker = new Schema({
     companyId: { type: Schema.Types.ObjectId, ref: 'Company', required: true, index: true },
     serialNumber: { type: String, required: true, unique: true, index: true },
-    alias: { type: String, required: true, index: true }
+    alias: { type: String, required: true, index: true },
+    emoji: { type: String }
 }, { timestamps: true })
 
 const poi = new Schema({
@@ -44,7 +47,8 @@ const poi = new Schema({
     title: { type: String, required: true },
     latitude: { type: Number, required: true },
     longitude: { type: Number, required: true },
-    color: { type: String, required: true }
+    color: { type: String, required: true },
+    emoji: { type: String }
 }, { timestamps: true })
 
 const user = new Schema({


### PR DESCRIPTION
## Resumen
- habilita detalle de tracker en `/backoffice/trackers/:id`
- permite editar solo el alias del tracker en ese detalle
- añade `emoji` persistente en DB/GraphQL para trackers y POIs
- añade selección de emoji en creación de trackers (`/trackers/new` y backoffice)
- añade edición de POIs (incluyendo emoji) en `/places/:poiId`
- actualiza mapa/listados para visualizar emojis

## Validaciones
- valida emoji permitido para trackers y POIs en backend
- rechaza emojis fuera de catálogo con `InputError`

## Specs añadidos/actualizados
- `fleet.service.spec.js`: casos de emoji por defecto, emoji válido e inválido
- `poi.service.spec.js`: casos de emoji por defecto, emoji válido e inválido
- `emoji-catalog.spec.js`: cobertura de normalización y errores

## Verificación
- `npm test -w track-api`
- `npm run typecheck -w track-app`