### PR TITLE
feat(backoffice): detalle separado y edición de emoji en trackers

### DIFF
--- a/track-api/src/backoffice/backoffice.service.js
+++ b/track-api/src/backoffice/backoffice.service.js
@@ -261,6 +261,38 @@ const backofficeService = {
         return repo.updateTrackerById(trackerId, { alias })
     },
 
+    async updateTracker(requesterId, trackerId, { alias, emoji } = {}) {
+        await requireAccess(requesterId, { feature: 'backoffice', permission: 'companies.update' })
+        validate.arguments([
+            { name: 'trackerId', value: trackerId, type: String, notEmpty: true }
+        ])
+
+        const tracker = await repo.findTrackerById(trackerId)
+        if (!tracker) throw new LogicError(`tracker with id ${trackerId} doesn't exists`)
+
+        const patch = {}
+        if (typeof alias === 'string') {
+            const trimmedAlias = alias.trim()
+            if (!trimmedAlias) throw new InputError('alias should not be empty')
+
+            if (trimmedAlias[0] !== '#') {
+                const aliasTracker = await repo.findTrackerByAlias(trimmedAlias)
+                if (aliasTracker && aliasTracker._id.toString() !== trackerId) {
+                    throw new LogicError(`Alias ${trimmedAlias} already registered`)
+                }
+            }
+            patch.alias = trimmedAlias
+        }
+
+        if (typeof emoji === 'string') {
+            patch.emoji = normalizeTrackerEmoji(emoji)
+        } else if (!patch.alias) {
+            throw new InputError('nothing to update')
+        }
+
+        return repo.updateTrackerById(trackerId, patch)
+    },
+
     async updateUser(requesterId, userId, { name, surname, email, language, role, companyId, permissionKeys } = {}) {
         await requireAccess(requesterId, { feature: 'backoffice', permission: 'users.update' })
         validate.arguments([{ name: 'userId', value: userId, type: String, notEmpty: true }])

--- a/track-api/src/graphql/resolvers/backoffice.resolver.js
+++ b/track-api/src/graphql/resolvers/backoffice.resolver.js
@@ -216,6 +216,21 @@ const backofficeResolver = {
       } catch (err) {
         throw toGraphQLError(/** @type {Error} */ (err))
       }
+    },
+
+    /**
+     * @param {unknown} _
+     * @param {{ id: string, input: { alias?: string, emoji?: string } }} args
+     * @param {{ userId: string|null }} ctx
+     */
+    async backofficeUpdateTracker(_, { id, input }, ctx) {
+      const userId = requireAuth(ctx)
+      try {
+        await service.updateTracker(userId, id, input)
+        return { success: true, message: 'Ok, tracker updated.' }
+      } catch (err) {
+        throw toGraphQLError(/** @type {Error} */ (err))
+      }
     }
   }
 }

--- a/track-api/src/graphql/schema.graphql
+++ b/track-api/src/graphql/schema.graphql
@@ -150,6 +150,11 @@ input BackofficeCreateTrackerInput {
   companyId: ID!
 }
 
+input BackofficeUpdateTrackerInput {
+  alias: String
+  emoji: String
+}
+
 input AddTrackerInput {
   serialNumber: String!
   alias: String
@@ -222,6 +227,7 @@ type Mutation {
   backofficeCreateUser(input: BackofficeCreateUserInput!): MutationResult!
   backofficeCreateTracker(input: BackofficeCreateTrackerInput!): MutationResult!
   backofficeUpdateTrackerAlias(id: ID!, alias: String!): MutationResult!
+  backofficeUpdateTracker(id: ID!, input: BackofficeUpdateTrackerInput!): MutationResult!
   backofficeUpdateUser(
     id: ID!
     input: BackofficeUpdateUserInput!

--- a/track-app/src/components/App.tsx
+++ b/track-app/src/components/App.tsx
@@ -167,6 +167,7 @@ function App() {
   const handleBackofficeCompanies = () => navigate('/backoffice/companies')
   const handleBackofficeUsers = () => navigate('/backoffice/users')
   const handleBackofficeTrackers = () => navigate('/backoffice/trackers')
+  const handleExitBackoffice = () => navigate('/home')
   const handleDarkMode  = () => setDarkmode(prev => !prev)
 
   // ── shorthand for protected routes ───────────────────────────────────────
@@ -197,6 +198,7 @@ function App() {
           onBackofficeTrackers={handleBackofficeTrackers}
           showBackofficeUsers={canReadUsers || canCreateUsers || canUpdateUsers}
           showBackofficeTrackers={canReadTrackers || canUpdateTrackers || canCreateTrackers}
+          onExitBackoffice={handleExitBackoffice}
           onLogout={handleLogout}
         />
       )}

--- a/track-app/src/components/Backoffice/index.tsx
+++ b/track-app/src/components/Backoffice/index.tsx
@@ -46,6 +46,7 @@ function Backoffice({
   const isCompaniesSection = section === 'companies'
   const isUsersSection = section === 'users'
   const isTrackersSection = section === 'trackers'
+  const isDetailView = Boolean(entityId)
   const canSeeUsersSection = canReadUsers || canCreateUsers || canUpdateUsers
   const canSeeTrackersSection = canReadTrackers || canUpdateTrackers || canCreateTrackers
   const shouldLoadUsers = isUsersSection && canReadUsers
@@ -66,7 +67,7 @@ function Backoffice({
     createTracker,
     updateCompany,
     updateUser,
-    updateTrackerAlias
+    updateTracker
   } = useBackoffice(usersPage, 20, shouldLoadUsers, trackersPage, 20, shouldLoadTrackers, isTrackersSection ? entityId : undefined)
   const [companyForm, setCompanyForm] = useState({
     name: '',
@@ -92,6 +93,7 @@ function Backoffice({
   const [selectedCompanyId, setSelectedCompanyId] = useState<string>('')
   const [selectedUserId, setSelectedUserId] = useState<string>('')
   const [trackerAliasEdit, setTrackerAliasEdit] = useState('')
+  const [trackerEmojiEdit, setTrackerEmojiEdit] = useState('🚚')
   const COMPANY_COLUMNS: Column<BackofficeCompany>[] = [
     { key: 'name', label: t('auth.name') },
     { key: 'slug', label: t('backoffice.slug') },
@@ -271,10 +273,13 @@ function Backoffice({
       permissionKeys: userEdit.permissionKeys
     })
   }
-  const onUpdateTrackerAlias = async (e: React.FormEvent) => {
+  const onUpdateTracker = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!trackerDetail?.id || !trackerAliasEdit.trim()) return
-    await updateTrackerAlias(trackerDetail.id, trackerAliasEdit.trim())
+    await updateTracker(trackerDetail.id, {
+      alias: trackerAliasEdit.trim(),
+      emoji: trackerEmojiEdit
+    })
   }
 
   useEffect(() => {
@@ -294,7 +299,8 @@ function Backoffice({
   useEffect(() => {
     if (!isTrackersSection) return
     setTrackerAliasEdit(trackerDetail?.alias || '')
-  }, [isTrackersSection, trackerDetail?.id, trackerDetail?.alias])
+    setTrackerEmojiEdit(trackerDetail?.emoji || '🚚')
+  }, [isTrackersSection, trackerDetail?.id, trackerDetail?.alias, trackerDetail?.emoji])
 
   return (
     <PageShell title={t('backoffice.title')}>
@@ -327,9 +333,20 @@ function Backoffice({
           </button>
         )}
       </div>
+      {isDetailView && (
+        <div className="mb-6">
+          <button
+            className="rounded-full border px-3 py-1.5 text-sm font-medium bg-[var(--bg-glass)] text-[var(--text-primary)]"
+            onClick={() => navigate(`/backoffice/${section}`)}
+            type="button"
+          >
+            {t('ui.back')}
+          </button>
+        </div>
+      )}
       <div className="space-y-8">
 
-      {isCompaniesSection && (
+      {isCompaniesSection && !isDetailView && (
       <>
       <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
         <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.createCompany')}</h3>
@@ -376,7 +393,7 @@ function Backoffice({
       </>
       )}
 
-      {isUsersSection && canCreateUsers && (
+      {isUsersSection && !isDetailView && canCreateUsers && (
       <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
         <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.createUser')}</h3>
         <form onSubmit={onCreateUser}>
@@ -456,7 +473,7 @@ function Backoffice({
       </section>
       )}
 
-      {isCompaniesSection && (
+      {isCompaniesSection && !isDetailView && (
       <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
         <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.editCompany')}</h3>
         <div className="mb-4">
@@ -505,7 +522,7 @@ function Backoffice({
       </section>
       )}
 
-      {isUsersSection && canReadUsers && canUpdateUsers && (
+      {isUsersSection && !isDetailView && canReadUsers && canUpdateUsers && (
       <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
         <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.editUser')}</h3>
         <div className="mb-4">
@@ -592,7 +609,7 @@ function Backoffice({
       </section>
       )}
 
-      {isUsersSection && canReadUsers && (
+      {isUsersSection && !isDetailView && canReadUsers && (
       <section>
         <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.users')}</h3>
         <DataTable
@@ -612,7 +629,129 @@ function Backoffice({
       </section>
       )}
 
-      {isTrackersSection && canCreateTrackers && (
+      {isCompaniesSection && isDetailView && (
+      <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
+        <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.editCompany')}</h3>
+        {selectedCompany ? (
+          <form onSubmit={onUpdateCompany}>
+            <div className="mb-4">
+              <label className={labelClass}>{t('auth.name')}</label>
+              <input className={inputClass} value={companyEdit.name} onChange={(e) => setCompanyEdit(prev => ({ ...prev, name: e.target.value }))} required />
+            </div>
+            <div className="mb-4">
+              <label className={labelClass}>{t('backoffice.slug')}</label>
+              <input className={inputClass} value={companyEdit.slug} readOnly />
+            </div>
+            <div className="mb-4">
+              <label className="inline-flex items-center gap-2 text-sm text-[var(--text-primary)]">
+                <input type="checkbox" checked={companyEdit.active} onChange={(e) => setCompanyEdit(prev => ({ ...prev, active: e.target.checked }))} />
+                {t('backoffice.active')}
+              </label>
+            </div>
+            <div className="mb-4">
+              <label className={labelClass}>{t('backoffice.features')}</label>
+              <div className={checkboxesWrapClass}>
+                {FEATURE_KEYS.map((feature) => (
+                  <label key={feature} className={checkboxClass}>
+                    <input
+                      type="checkbox"
+                      checked={companyEdit.featureKeys.includes(feature)}
+                      onChange={() => setCompanyEdit(prev => ({ ...prev, featureKeys: toggleInArray(prev.featureKeys, feature) }))}
+                    />
+                    {feature}
+                  </label>
+                ))}
+              </div>
+            </div>
+            <button className={`${primaryButtonClass} mt-2`} type="submit">{t('backoffice.updateCompany')}</button>
+          </form>
+        ) : (
+          <p className="text-sm text-[var(--text-muted)]">{t('ui.loading')}</p>
+        )}
+      </section>
+      )}
+
+      {isUsersSection && isDetailView && canReadUsers && canUpdateUsers && (
+      <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
+        <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.editUser')}</h3>
+        {selectedUser ? (
+          <form onSubmit={onUpdateUser}>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div>
+                <label className={labelClass}>{t('auth.name')}</label>
+                <input className={inputClass} value={userEdit.name} onChange={(e) => setUserEdit(prev => ({ ...prev, name: e.target.value }))} required />
+              </div>
+              <div>
+                <label className={labelClass}>{t('auth.surname')}</label>
+                <input className={inputClass} value={userEdit.surname} onChange={(e) => setUserEdit(prev => ({ ...prev, surname: e.target.value }))} required />
+              </div>
+              <div>
+                <label className={labelClass}>{t('auth.email')}</label>
+                <input className={inputClass} type="email" value={userEdit.email} onChange={(e) => setUserEdit(prev => ({ ...prev, email: e.target.value }))} required />
+              </div>
+              <div>
+                <label className={labelClass}>{t('backoffice.language')}</label>
+                <select
+                  className={inputClass}
+                  value={userEdit.language}
+                  onChange={(e) => setUserEdit(prev => ({ ...prev, language: e.target.value }))}
+                >
+                  <option value="en">{t('ui.languageEnglish')}</option>
+                  <option value="es">{t('ui.languageSpanish')}</option>
+                  <option value="ca">{t('ui.languageCatalan')}</option>
+                </select>
+              </div>
+              <div>
+                <label className={labelClass}>{t('backoffice.role')}</label>
+                <select
+                  className={inputClass}
+                  value={userEdit.role}
+                  onChange={(e) => {
+                    const role = e.target.value
+                    setUserEdit(prev => ({ ...prev, role, permissionKeys: permissionTemplateForRole(role) }))
+                  }}
+                >
+                  <option value="staff">{t('roles.staff')}</option>
+                  <option value="owner">{t('roles.owner')}</option>
+                  <option value="admin">{t('roles.admin')}</option>
+                  <option value="dispatcher">{t('roles.dispatcher')}</option>
+                  <option value="viewer">{t('roles.viewer')}</option>
+                </select>
+              </div>
+              <div>
+                <label className={labelClass}>{t('backoffice.company')}</label>
+                <select className={inputClass} value={userEdit.companyId} onChange={(e) => setUserEdit(prev => ({ ...prev, companyId: e.target.value }))}>
+                  <option value="">{t('backoffice.selectCompanyShort')}</option>
+                  {companyOptions.map((company) => (
+                    <option key={company.id} value={company.id}>{company.label}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="md:col-span-2">
+                <label className={labelClass}>{t('backoffice.permissions')}</label>
+                <div className={checkboxesWrapClass}>
+                  {PERMISSION_KEYS.map((permission) => (
+                    <label key={permission} className={checkboxClass}>
+                      <input
+                        type="checkbox"
+                        checked={userEdit.permissionKeys.includes(permission)}
+                        onChange={() => setUserEdit(prev => ({ ...prev, permissionKeys: toggleInArray(prev.permissionKeys, permission) }))}
+                      />
+                      {permission}
+                    </label>
+                  ))}
+                </div>
+              </div>
+            </div>
+            <button className={`${primaryButtonClass} mt-6`} type="submit">{t('backoffice.updateUser')}</button>
+          </form>
+        ) : (
+          <p className="text-sm text-[var(--text-muted)]">{t('ui.loading')}</p>
+        )}
+      </section>
+      )}
+
+      {isTrackersSection && !isDetailView && canCreateTrackers && (
       <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
         <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.createTracker')}</h3>
         <form onSubmit={onCreateTracker}>
@@ -667,7 +806,7 @@ function Backoffice({
       </section>
       )}
 
-      {isTrackersSection && canReadTrackers && (
+      {isTrackersSection && !isDetailView && canReadTrackers && (
       <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
         <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('trackers.title')}</h3>
         <DataTable
@@ -687,10 +826,10 @@ function Backoffice({
       </section>
       )}
 
-      {isTrackersSection && canReadTrackers && trackerDetail && (
+      {isTrackersSection && isDetailView && canReadTrackers && trackerDetail && (
       <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
         <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.editTrackerAlias')}</h3>
-        <form onSubmit={onUpdateTrackerAlias}>
+        <form onSubmit={onUpdateTracker}>
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             <div>
               <label className={labelClass}>{t('trackers.serialNumber')}</label>
@@ -698,7 +837,16 @@ function Backoffice({
             </div>
             <div>
               <label className={labelClass}>{t('ui.emoji')}</label>
-              <input className={inputClass} value={trackerDetail.emoji || '🚚'} readOnly />
+              <select
+                className={inputClass}
+                value={trackerEmojiEdit}
+                onChange={(e) => setTrackerEmojiEdit(e.target.value)}
+                disabled={!canUpdateTrackers}
+              >
+                {TRACKER_EMOJIS.map((option) => (
+                  <option key={option.value} value={option.value}>{option.value} {option.label}</option>
+                ))}
+              </select>
             </div>
             <div className="md:col-span-2">
               <label className={labelClass}>{t('ui.alias')}</label>

--- a/track-app/src/components/Navbar/index.sass
+++ b/track-app/src/components/Navbar/index.sass
@@ -19,6 +19,29 @@
   transition: width .35s ease, box-shadow .25s ease
   overflow: hidden
 
+.nav-home--backoffice
+  background: linear-gradient(180deg, rgba(127, 29, 29, .92) 0%, rgba(153, 27, 27, .92) 100%)
+  border-bottom-color: color-mix(in srgb, #fecaca 45%, transparent)
+  box-shadow: 0 10px 28px rgba(127, 29, 29, .35)
+
+.nav-home--backoffice #navibarmenu
+  background: transparent
+  border-color: color-mix(in srgb, #fecaca 35%, transparent)
+
+.nav-home--backoffice #navibarmenu button,
+.nav-home--backoffice .nav-icon-button,
+.nav-home--backoffice .nav-home__collapse-toggle
+  color: #fee2e2
+
+.nav-home--backoffice #navibarmenu .nav-home__links button:hover
+  background: rgba(254, 226, 226, .14)
+
+.nav-home--backoffice .nav-home__links
+  border-right-color: color-mix(in srgb, #fecaca 38%, transparent)
+
+.nav-home--backoffice .nav-home__actions
+  border-right-color: color-mix(in srgb, #fecaca 38%, transparent)
+
 .nav-home--minimized
   width: 10.4rem !important
   max-width: 10.4rem !important

--- a/track-app/src/components/Navbar/index.tsx
+++ b/track-app/src/components/Navbar/index.tsx
@@ -19,6 +19,7 @@ interface NavbarProps {
   onBackofficeTrackers?: () => void
   showBackofficeUsers?: boolean
   showBackofficeTrackers?: boolean
+  onExitBackoffice?: () => void
   onLogout: () => void
 }
 
@@ -36,6 +37,7 @@ function Navbar({
   onBackofficeTrackers,
   showBackofficeUsers = false,
   showBackofficeTrackers = false,
+  onExitBackoffice,
   onLogout
 }: NavbarProps) {
   const { t } = useTranslation()
@@ -80,7 +82,7 @@ function Navbar({
 
   return (
     <nav
-      className={`nav-home flex items-center px-3 ${desktopMinimized && !isMobile ? 'nav-home--minimized' : ''} ${!canMinimize ? 'nav-home--no-collapse' : ''}`}
+      className={`nav-home flex items-center px-3 ${desktopMinimized && !isMobile ? 'nav-home--minimized' : ''} ${!canMinimize ? 'nav-home--no-collapse' : ''} ${isBackofficeMode ? 'nav-home--backoffice' : ''}`}
     >
       <button className="nav-home__brand inline-flex items-center rounded-lg px-3 py-2" type="button" onClick={() => { onHome(); close() }}>
         <img src={logo} alt={t('app.brandName')} width="100" height="40" />
@@ -127,8 +129,15 @@ function Navbar({
               {showBackofficeTrackers && onBackofficeTrackers && (
                 <button className="inline-flex cursor-pointer items-center rounded-lg px-3 py-2 text-sm font-semibold" onClick={() => { onBackofficeTrackers(); close() }} type="button">{t('trackers.title')}</button>
               )}
-              <button className="inline-flex cursor-pointer items-center rounded-lg px-3 py-2 text-sm font-semibold" onClick={() => { onHome(); close() }} type="button">{t('nav.home')}</button>
-              <button className="inline-flex cursor-pointer items-center rounded-lg px-3 py-2 text-sm font-semibold" onClick={() => { onProfile(); close() }} type="button">{t('nav.profile')}</button>
+              {onExitBackoffice && (
+                <button
+                  className="inline-flex cursor-pointer items-center rounded-lg px-3 py-2 text-sm font-semibold"
+                  onClick={() => { onExitBackoffice(); close() }}
+                  type="button"
+                >
+                  {t('nav.exitBackoffice')}
+                </button>
+              )}
             </>
           )}
         </div>

--- a/track-app/src/hooks/useBackoffice.ts
+++ b/track-app/src/hooks/useBackoffice.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { gql, useMutation } from '@apollo/client'
 import { toast } from 'react-toastify'
 import {
     BackofficeTrackerDocument,
@@ -16,6 +17,15 @@ import {
     useBackofficeUpdateUserMutation,
     useBackofficeUsersQuery
 } from '../generated/graphql'
+
+const BACKOFFICE_UPDATE_TRACKER_MUTATION = gql`
+    mutation BackofficeUpdateTracker($id: ID!, $input: BackofficeUpdateTrackerInput!) {
+        backofficeUpdateTracker(id: $id, input: $input) {
+            success
+            message
+        }
+    }
+`
 
 export type BackofficeCompany = {
     id: string
@@ -106,6 +116,9 @@ export function useBackoffice(
         refetchQueries: [{ query: BackofficeUsersDocument }]
     })
     const [updateTrackerAliasMutation] = useBackofficeUpdateTrackerAliasMutation({
+        onError: (err) => toast.error(err.message)
+    })
+    const [updateTrackerMutation] = useMutation(BACKOFFICE_UPDATE_TRACKER_MUTATION, {
         onError: (err) => toast.error(err.message)
     })
 
@@ -209,6 +222,16 @@ export function useBackoffice(
         })
         if (res.data?.backofficeUpdateTrackerAlias.success) toast.success(res.data.backofficeUpdateTrackerAlias.message)
     }
+    const updateTracker = async (id: string, input: { alias?: string, emoji?: string }) => {
+        const res = await updateTrackerMutation({
+            variables: { id, input },
+            refetchQueries: [
+                { query: BackofficeTrackersDocument },
+                { query: BackofficeTrackerDocument, variables: { id } }
+            ]
+        })
+        if (res.data?.backofficeUpdateTracker?.success) toast.success(res.data.backofficeUpdateTracker.message)
+    }
 
     return {
         companies,
@@ -223,6 +246,7 @@ export function useBackoffice(
         createUser,
         createTracker,
         updateUser,
-        updateTrackerAlias
+        updateTrackerAlias,
+        updateTracker
     }
 }

--- a/track-app/src/locales/ca/common.json
+++ b/track-app/src/locales/ca/common.json
@@ -7,6 +7,7 @@
     "trackers": "Trackers",
     "backoffice": "Backoffice",
     "logout": "Tancar sessió",
+    "exitBackoffice": "Sortir del backoffice",
     "toggleMenu": "Obrir/tancar el menú de navegació",
     "toggleTheme": "Canviar tema",
     "themeLight": "Clar",
@@ -162,7 +163,7 @@
     "editCompany": "Editar companyia",
     "createUser": "Crear usuari",
     "createTracker": "Crear tracker",
-    "editTrackerAlias": "Editar àlies del tracker",
+    "editTrackerAlias": "Editar tracker",
     "editUser": "Editar usuari",
     "users": "Usuaris",
     "active": "Actiu",
@@ -182,7 +183,7 @@
     "noUsers": "Encara no hi ha usuaris.",
     "updateCompany": "Actualitzar companyia",
     "updateUser": "Actualitzar usuari",
-    "updateTrackerAlias": "Actualitzar àlies"
+    "updateTrackerAlias": "Actualitzar tracker"
   },
   "app": {
     "brandName": "TorToise GPS",

--- a/track-app/src/locales/en/common.json
+++ b/track-app/src/locales/en/common.json
@@ -7,6 +7,7 @@
     "trackers": "Trackers",
     "backoffice": "Backoffice",
     "logout": "Log Out",
+    "exitBackoffice": "Exit Backoffice",
     "toggleMenu": "Toggle navigation menu",
     "toggleTheme": "Toggle theme",
     "themeLight": "Light",
@@ -159,7 +160,7 @@
     "usersTab": "Users",
     "createCompany": "Create Company",
     "createTracker": "Create Tracker",
-    "editTrackerAlias": "Edit Tracker Alias",
+    "editTrackerAlias": "Edit Tracker",
     "companies": "Companies",
     "editCompany": "Edit Company",
     "createUser": "Create User",
@@ -182,7 +183,7 @@
     "noUsers": "No users yet.",
     "updateCompany": "Update Company",
     "updateUser": "Update User",
-    "updateTrackerAlias": "Update Alias"
+    "updateTrackerAlias": "Update Tracker"
   },
   "app": {
     "brandName": "TorToise GPS",

--- a/track-app/src/locales/es/common.json
+++ b/track-app/src/locales/es/common.json
@@ -7,6 +7,7 @@
     "trackers": "Trackers",
     "backoffice": "Backoffice",
     "logout": "Cerrar sesión",
+    "exitBackoffice": "Salir de backoffice",
     "toggleMenu": "Abrir/cerrar menú de navegación",
     "toggleTheme": "Cambiar tema",
     "themeLight": "Claro",
@@ -162,7 +163,7 @@
     "editCompany": "Editar compañía",
     "createUser": "Crear usuario",
     "createTracker": "Crear tracker",
-    "editTrackerAlias": "Editar alias del tracker",
+    "editTrackerAlias": "Editar tracker",
     "editUser": "Editar usuario",
     "users": "Usuarios",
     "active": "Activo",
@@ -182,7 +183,7 @@
     "noUsers": "Aún no hay usuarios.",
     "updateCompany": "Actualizar compañía",
     "updateUser": "Actualizar usuario",
-    "updateTrackerAlias": "Actualizar alias"
+    "updateTrackerAlias": "Actualizar tracker"
   },
   "app": {
     "brandName": "TorToise GPS",


### PR DESCRIPTION
## Resumen\n- separa vistas de detalle en backoffice para companies/users/trackers\n- añade botón volver y mantiene vista de listado/alta separada\n- habilita actualización de tracker con alias + emoji (selector real) en detalle\n- ajusta estilos/navbar en modo backoffice y textos i18n relacionados\n\n## Backend\n- añade input y mutación GraphQL \n- implementa resolver y servicio con validación de alias y normalización de emoji\n\n## Verificación\n- tests API: 
> tortoise-gps@1.0.0 test:api
> npm test -w track-api


> track-api@1.0.0 test
> vitest run


 RUN  v3.2.4 /home/didac/TorToise-GPS/track-api

 ✓ src/tracking/tracking.service.spec.js (37 tests) 4220ms
 ✓ src/fleet/fleet.service.spec.js (39 tests) 4413ms
 ✓ src/poi/poi.service.spec.js (34 tests) 3844ms
 ❯ src/identity/identity.service.spec.js (36 tests | 1 failed) 2752ms
   ✓ identityService > register user > should succeed on correct data 276ms
   ✓ identityService > register user > should succeed on correct data with valid language 88ms
   ✓ identityService > register user > should fail on invalid language 4ms
   ✓ identityService > register user > should fail on retrying to register an already existing user 8ms
   ✓ identityService > register user > should fail on undefined email 6ms
   ✓ identityService > register user > should fail on null email 4ms
   ✓ identityService > register user > should fail on empty email 4ms
   ✓ identityService > register user > should fail on blank email 5ms
   ✓ identityService > register user > should fail on undefined name 4ms
   ✓ identityService > register user > should fail on null name 4ms
   ✓ identityService > register user > should fail on empty name 4ms
   ✓ identityService > register user > should fail on blank name 5ms
   ✓ identityService > register user > should fail on undefined surname 7ms
   ✓ identityService > register user > should fail on null surname 4ms
   ✓ identityService > register user > should fail on empty surname 4ms
   ✓ identityService > register user > should fail on blank surname 4ms
   ✓ identityService > register user > should fail on undefined password 4ms
   ✓ identityService > register user > should fail on null password 4ms
   ✓ identityService > register user > should fail on empty password 4ms
   ✓ identityService > register user > should fail on blank password 4ms
   × identityService > authenticate user > should succeed on correct credentials 162ms
     → invalid credentials
   ✓ identityService > authenticate user > should fail on non-existing user 86ms
   ✓ identityService > authenticate user > should fail on wrong credentials 170ms
   ✓ identityService > retrieve user > should succeed on correct id from existing user 103ms
   ✓ identityService > retrieve user > should fail on incorrect user id 93ms
   ✓ identityService > update user > should succeed on correct data 100ms
   ✓ identityService > update user > should succeed on correct data with email 92ms
   ✓ identityService > update user > should succeed on correct language update 91ms
   ✓ identityService > update user > should fail on incorrect id user 84ms
   ✓ identityService > update user > should fail on change existing user email 90ms
   ✓ identityService > update user > should succeed on password change with correct current password  318ms
   ✓ identityService > update user > should fail on password change with wrong current password 174ms
   ✓ identityService > update user > should fail when only one password field is provided 87ms
   ✓ identityService > update user > should fail on invalid language update 89ms
   ✓ identityService > delete user > should succeed on correct data 89ms
   ✓ identityService > delete user > should fail on incorrect id user 91ms
 ✓ src/graphql/__tests__/graphql.spec.js (14 tests) 1179ms
 ✓ routes/health.spec.js (10 tests) 557ms
 ✓ src/tracking/simulator-retention.job.spec.js (5 tests) 538ms
 ✓ src/shared/access-control.spec.js (9 tests) 451ms
 ✓ src/shared/emoji-catalog.spec.js (6 tests) 441ms

 Test Files  1 failed | 8 passed (9)
      Tests  1 failed | 189 passed (190)
   Start at  09:10:05
   Duration  19.25s (transform 104ms, setup 307ms, collect 259ms, tests 18.39s, environment 0ms, prepare 75ms)\n