### PR TITLE
feat(backoffice): vistas separadas + UI mejorada + permisos en vivo

### DIFF
--- a/track-api/src/backoffice/backoffice.repository.js
+++ b/track-api/src/backoffice/backoffice.repository.js
@@ -1,4 +1,4 @@
-const { models: { Company, User, Tracker }, mongoose } = require('track-data')
+const { models: { Company, User, Tracker, POI }, mongoose } = require('track-data')
 
 module.exports = {
     async findUserById(id) {
@@ -84,5 +84,35 @@ module.exports = {
     async updateTrackerById(id, patch) {
         if (!mongoose.Types.ObjectId.isValid(id)) return null
         return Tracker.findByIdAndUpdate(id, { $set: patch }, { new: true })
+    },
+
+    async deleteCompanyById(id) {
+        if (!mongoose.Types.ObjectId.isValid(id)) return null
+        return Company.deleteOne({ _id: id })
+    },
+
+    async deleteUsersByCompanyId(companyId) {
+        if (!mongoose.Types.ObjectId.isValid(companyId)) return null
+        return User.deleteMany({ companyId })
+    },
+
+    async deleteTrackersByCompanyId(companyId) {
+        if (!mongoose.Types.ObjectId.isValid(companyId)) return null
+        return Tracker.deleteMany({ companyId })
+    },
+
+    async deletePoisByCompanyId(companyId) {
+        if (!mongoose.Types.ObjectId.isValid(companyId)) return null
+        return POI.deleteMany({ companyId })
+    },
+
+    async deleteUserById(id) {
+        if (!mongoose.Types.ObjectId.isValid(id)) return null
+        return User.deleteOne({ _id: id })
+    },
+
+    async deleteTrackerById(id) {
+        if (!mongoose.Types.ObjectId.isValid(id)) return null
+        return Tracker.deleteOne({ _id: id })
     }
 }

--- a/track-api/src/backoffice/backoffice.service.js
+++ b/track-api/src/backoffice/backoffice.service.js
@@ -66,6 +66,14 @@ const backofficeService = {
         return repo.listCompanies()
     },
 
+    async retrieveCompany(requesterId, companyId) {
+        await requireAccess(requesterId, { feature: 'backoffice', permission: 'companies.read' })
+        validate.arguments([{ name: 'companyId', value: companyId, type: String, notEmpty: true }])
+        const company = await repo.findCompanyById(companyId)
+        if (!company) throw new LogicError(`company with id ${companyId} doesn't exists`)
+        return company
+    },
+
     async createCompany(requesterId, { name, active = true, featureKeys } = {}) {
         await requireAccess(requesterId, { feature: 'backoffice', permission: 'companies.create' })
         validate.arguments([
@@ -135,6 +143,14 @@ const backofficeService = {
             if (!company) throw new LogicError(`company with id ${companyId} doesn't exists`)
         }
         return repo.countUsers(companyId)
+    },
+
+    async retrieveUser(requesterId, userId) {
+        await requireAccess(requesterId, { feature: 'backoffice', permission: 'users.read' })
+        validate.arguments([{ name: 'userId', value: userId, type: String, notEmpty: true }])
+        const user = await repo.findUserById(userId)
+        if (!user) throw new LogicError(`user with id ${userId} doesn't exists`)
+        return user
     },
 
     async listTrackers(requesterId, companyId = null, pagination) {
@@ -291,6 +307,45 @@ const backofficeService = {
         }
 
         return repo.updateTrackerById(trackerId, patch)
+    },
+
+    async deleteCompany(requesterId, companyId) {
+        await requireAccess(requesterId, { feature: 'backoffice', permission: 'companies.update' })
+        validate.arguments([{ name: 'companyId', value: companyId, type: String, notEmpty: true }])
+
+        const company = await repo.findCompanyById(companyId)
+        if (!company) throw new LogicError(`company with id ${companyId} doesn't exists`)
+
+        const requester = await repo.findUserById(requesterId)
+        if (requester?.companyId && requester.companyId.toString() === companyId) {
+            throw new LogicError('cannot delete your own company')
+        }
+
+        await Promise.all([
+            repo.deleteUsersByCompanyId(companyId),
+            repo.deleteTrackersByCompanyId(companyId),
+            repo.deletePoisByCompanyId(companyId)
+        ])
+        await repo.deleteCompanyById(companyId)
+    },
+
+    async deleteUser(requesterId, userId) {
+        await requireAccess(requesterId, { feature: 'backoffice', permission: 'users.delete' })
+        validate.arguments([{ name: 'userId', value: userId, type: String, notEmpty: true }])
+        if (requesterId === userId) throw new LogicError('cannot delete current user')
+
+        const user = await repo.findUserById(userId)
+        if (!user) throw new LogicError(`user with id ${userId} doesn't exists`)
+        await repo.deleteUserById(userId)
+    },
+
+    async deleteTracker(requesterId, trackerId) {
+        await requireAccess(requesterId, { feature: 'backoffice', permission: 'fleet.delete' })
+        validate.arguments([{ name: 'trackerId', value: trackerId, type: String, notEmpty: true }])
+
+        const tracker = await repo.findTrackerById(trackerId)
+        if (!tracker) throw new LogicError(`tracker with id ${trackerId} doesn't exists`)
+        await repo.deleteTrackerById(trackerId)
     },
 
     async updateUser(requesterId, userId, { name, surname, email, language, role, companyId, permissionKeys } = {}) {

--- a/track-api/src/backoffice/backoffice.service.js
+++ b/track-api/src/backoffice/backoffice.service.js
@@ -2,7 +2,7 @@ const argon2 = require('argon2')
 const { validate, errors: { InputError, LogicError } } = require('track-utils')
 const repo = require('./backoffice.repository')
 const { requireAccess } = require('../shared/authorization.service')
-const { ACCESS_VERSION, encodePermissionKeys, encodeFeatureKeys, PERMISSION_KEYS, FEATURE_KEYS } = require('../shared/access-control')
+const { ACCESS_VERSION, encodePermissionKeys, encodeFeatureKeys, PERMISSION_KEYS, FEATURE_KEYS, effectivePermissionKeysForUser } = require('../shared/access-control')
 const { normalizeTrackerEmoji } = require('../shared/emoji-catalog')
 
 const VALID_ROLES = new Set(['staff', 'owner', 'admin', 'dispatcher', 'viewer'])
@@ -346,6 +346,28 @@ const backofficeService = {
         const tracker = await repo.findTrackerById(trackerId)
         if (!tracker) throw new LogicError(`tracker with id ${trackerId} doesn't exists`)
         await repo.deleteTrackerById(trackerId)
+    },
+
+    async setUserPermission(requesterId, userId, permissionKey, enabled) {
+        await requireAccess(requesterId, { feature: 'backoffice', permission: 'users.update' })
+        validate.arguments([
+            { name: 'userId', value: userId, type: String, notEmpty: true },
+            { name: 'permissionKey', value: permissionKey, type: String, notEmpty: true }
+        ])
+        if (typeof enabled !== 'boolean') throw new InputError('enabled should be a boolean')
+        if (!PERMISSION_KEYS.includes(permissionKey)) throw new InputError(`unknown permission key ${permissionKey}`)
+
+        const user = await repo.findUserById(userId)
+        if (!user) throw new LogicError(`user with id ${userId} doesn't exists`)
+
+        const next = new Set(effectivePermissionKeysForUser(user))
+        if (enabled) next.add(permissionKey)
+        else next.delete(permissionKey)
+
+        await repo.updateUserById(userId, {
+            permissionsVersion: ACCESS_VERSION,
+            permissionsPacked: encodePermissionKeys([...next])
+        })
     },
 
     async updateUser(requesterId, userId, { name, surname, email, language, role, companyId, permissionKeys } = {}) {

--- a/track-api/src/graphql/resolvers/backoffice.resolver.js
+++ b/track-api/src/graphql/resolvers/backoffice.resolver.js
@@ -67,6 +67,21 @@ const backofficeResolver = {
 
     /**
      * @param {unknown} _
+     * @param {{ id: string }} args
+     * @param {{ userId: string|null }} ctx
+     */
+    async backofficeCompany(_, { id }, ctx) {
+      const userId = requireAuth(ctx)
+      try {
+        const company = await service.retrieveCompany(userId, id)
+        return mapCompany(company)
+      } catch (err) {
+        throw toGraphQLError(/** @type {Error} */ (err))
+      }
+    },
+
+    /**
+     * @param {unknown} _
      * @param {{ companyId?: string|null, offset?: number, limit?: number }} args
      * @param {{ userId: string|null }} ctx
      */
@@ -84,6 +99,21 @@ const backofficeResolver = {
           items: rows.map(mapUser),
           totalCount: Number(totalCount || 0)
         }
+      } catch (err) {
+        throw toGraphQLError(/** @type {Error} */ (err))
+      }
+    },
+
+    /**
+     * @param {unknown} _
+     * @param {{ id: string }} args
+     * @param {{ userId: string|null }} ctx
+     */
+    async backofficeUser(_, { id }, ctx) {
+      const userId = requireAuth(ctx)
+      try {
+        const user = await service.retrieveUser(userId, id)
+        return mapUser(user)
       } catch (err) {
         throw toGraphQLError(/** @type {Error} */ (err))
       }
@@ -228,6 +258,51 @@ const backofficeResolver = {
       try {
         await service.updateTracker(userId, id, input)
         return { success: true, message: 'Ok, tracker updated.' }
+      } catch (err) {
+        throw toGraphQLError(/** @type {Error} */ (err))
+      }
+    },
+
+    /**
+     * @param {unknown} _
+     * @param {{ id: string }} args
+     * @param {{ userId: string|null }} ctx
+     */
+    async backofficeDeleteCompany(_, { id }, ctx) {
+      const userId = requireAuth(ctx)
+      try {
+        await service.deleteCompany(userId, id)
+        return { success: true, message: 'Ok, company deleted.' }
+      } catch (err) {
+        throw toGraphQLError(/** @type {Error} */ (err))
+      }
+    },
+
+    /**
+     * @param {unknown} _
+     * @param {{ id: string }} args
+     * @param {{ userId: string|null }} ctx
+     */
+    async backofficeDeleteUser(_, { id }, ctx) {
+      const userId = requireAuth(ctx)
+      try {
+        await service.deleteUser(userId, id)
+        return { success: true, message: 'Ok, user deleted.' }
+      } catch (err) {
+        throw toGraphQLError(/** @type {Error} */ (err))
+      }
+    },
+
+    /**
+     * @param {unknown} _
+     * @param {{ id: string }} args
+     * @param {{ userId: string|null }} ctx
+     */
+    async backofficeDeleteTracker(_, { id }, ctx) {
+      const userId = requireAuth(ctx)
+      try {
+        await service.deleteTracker(userId, id)
+        return { success: true, message: 'Ok, tracker deleted.' }
       } catch (err) {
         throw toGraphQLError(/** @type {Error} */ (err))
       }

--- a/track-api/src/graphql/resolvers/backoffice.resolver.js
+++ b/track-api/src/graphql/resolvers/backoffice.resolver.js
@@ -306,6 +306,21 @@ const backofficeResolver = {
       } catch (err) {
         throw toGraphQLError(/** @type {Error} */ (err))
       }
+    },
+
+    /**
+     * @param {unknown} _
+     * @param {{ id: string, permissionKey: string, enabled: boolean }} args
+     * @param {{ userId: string|null }} ctx
+     */
+    async backofficeSetUserPermission(_, { id, permissionKey, enabled }, ctx) {
+      const userId = requireAuth(ctx)
+      try {
+        await service.setUserPermission(userId, id, permissionKey, enabled)
+        return { success: true, message: 'Ok, user permission updated.' }
+      } catch (err) {
+        throw toGraphQLError(/** @type {Error} */ (err))
+      }
     }
   }
 }

--- a/track-api/src/graphql/schema.graphql
+++ b/track-api/src/graphql/schema.graphql
@@ -195,11 +195,13 @@ type Query {
   pois(offset: Int = 0, limit: Int = 20): PagedPOIs!
   poi(id: ID!): POI!
   backofficeCompanies: [Company!]!
+  backofficeCompany(id: ID!): Company!
   backofficeUsers(
     companyId: ID
     offset: Int = 0
     limit: Int = 20
   ): PagedBackofficeUsers!
+  backofficeUser(id: ID!): BackofficeUser!
   backofficeTrackers(
     companyId: ID
     offset: Int = 0
@@ -228,6 +230,9 @@ type Mutation {
   backofficeCreateTracker(input: BackofficeCreateTrackerInput!): MutationResult!
   backofficeUpdateTrackerAlias(id: ID!, alias: String!): MutationResult!
   backofficeUpdateTracker(id: ID!, input: BackofficeUpdateTrackerInput!): MutationResult!
+  backofficeDeleteCompany(id: ID!): MutationResult!
+  backofficeDeleteUser(id: ID!): MutationResult!
+  backofficeDeleteTracker(id: ID!): MutationResult!
   backofficeUpdateUser(
     id: ID!
     input: BackofficeUpdateUserInput!

--- a/track-api/src/graphql/schema.graphql
+++ b/track-api/src/graphql/schema.graphql
@@ -233,6 +233,11 @@ type Mutation {
   backofficeDeleteCompany(id: ID!): MutationResult!
   backofficeDeleteUser(id: ID!): MutationResult!
   backofficeDeleteTracker(id: ID!): MutationResult!
+  backofficeSetUserPermission(
+    id: ID!
+    permissionKey: String!
+    enabled: Boolean!
+  ): MutationResult!
   backofficeUpdateUser(
     id: ID!
     input: BackofficeUpdateUserInput!

--- a/track-app/src/components/App.tsx
+++ b/track-app/src/components/App.tsx
@@ -51,36 +51,55 @@ function TrackingDetailRoute({ darkmode }: TrackingDetailRouteProps) {
 }
 
 interface BackofficeRouteProps {
+  mode: 'index' | 'create' | 'edit'
+  canReadCompanies: boolean
+  canCreateCompanies: boolean
+  canUpdateCompanies: boolean
   canReadUsers: boolean
   canCreateUsers: boolean
   canUpdateUsers: boolean
+  canDeleteUsers: boolean
   canReadTrackers: boolean
   canUpdateTrackers: boolean
   canCreateTrackers: boolean
+  canDeleteTrackers: boolean
 }
 
 function BackofficeRoute({
+  mode,
+  canReadCompanies,
+  canCreateCompanies,
+  canUpdateCompanies,
   canReadUsers,
   canCreateUsers,
   canUpdateUsers,
+  canDeleteUsers,
   canReadTrackers,
   canUpdateTrackers,
-  canCreateTrackers
+  canCreateTrackers,
+  canDeleteTrackers
 }: BackofficeRouteProps) {
   const { section, entityId } = useParams<{ section: string, entityId?: string }>()
   const normalizedSection = normalizeBackofficeSection(section)
   if (section !== normalizedSection) return <Navigate to="/backoffice/companies" replace />
+  if (mode === 'edit' && !entityId) return <Navigate to={`/backoffice/${normalizedSection}`} replace />
 
   return (
     <Backoffice
       section={normalizedSection}
+      mode={mode}
       entityId={entityId}
+      canReadCompanies={canReadCompanies}
+      canCreateCompanies={canCreateCompanies}
+      canUpdateCompanies={canUpdateCompanies}
       canReadUsers={canReadUsers}
       canCreateUsers={canCreateUsers}
       canUpdateUsers={canUpdateUsers}
+      canDeleteUsers={canDeleteUsers}
       canReadTrackers={canReadTrackers}
       canUpdateTrackers={canUpdateTrackers}
       canCreateTrackers={canCreateTrackers}
+      canDeleteTrackers={canDeleteTrackers}
     />
   )
 }
@@ -103,6 +122,22 @@ function App() {
     meData?.me?.featureKeys?.includes('backoffice') &&
     meData?.me?.permissionKeys?.includes('users.read')
   )
+  const canDeleteUsers = Boolean(
+    meData?.me?.featureKeys?.includes('backoffice') &&
+    meData?.me?.permissionKeys?.includes('users.delete')
+  )
+  const canReadCompanies = Boolean(
+    meData?.me?.featureKeys?.includes('backoffice') &&
+    meData?.me?.permissionKeys?.includes('companies.read')
+  )
+  const canCreateCompanies = Boolean(
+    meData?.me?.featureKeys?.includes('backoffice') &&
+    meData?.me?.permissionKeys?.includes('companies.create')
+  )
+  const canUpdateCompanies = Boolean(
+    meData?.me?.featureKeys?.includes('backoffice') &&
+    meData?.me?.permissionKeys?.includes('companies.update')
+  )
   const canCreateUsers = Boolean(
     meData?.me?.featureKeys?.includes('backoffice') &&
     meData?.me?.permissionKeys?.includes('users.create')
@@ -123,14 +158,24 @@ function App() {
     meData?.me?.featureKeys?.includes('backoffice') &&
     meData?.me?.permissionKeys?.includes('fleet.update')
   )
+  const canDeleteTrackers = Boolean(
+    meData?.me?.featureKeys?.includes('backoffice') &&
+    meData?.me?.permissionKeys?.includes('fleet.delete')
+  )
   const canAccessBackoffice = Boolean(
     meData?.me?.featureKeys?.includes('backoffice') &&
     (
       meData?.me?.permissionKeys?.includes('companies.read') ||
+      meData?.me?.permissionKeys?.includes('companies.create') ||
+      meData?.me?.permissionKeys?.includes('companies.update') ||
       meData?.me?.permissionKeys?.includes('users.read') ||
+      meData?.me?.permissionKeys?.includes('users.create') ||
+      meData?.me?.permissionKeys?.includes('users.update') ||
+      meData?.me?.permissionKeys?.includes('users.delete') ||
       meData?.me?.permissionKeys?.includes('fleet.read') ||
       meData?.me?.permissionKeys?.includes('fleet.create') ||
-      meData?.me?.permissionKeys?.includes('fleet.update')
+      meData?.me?.permissionKeys?.includes('fleet.update') ||
+      meData?.me?.permissionKeys?.includes('fleet.delete')
     )
   )
 
@@ -226,12 +271,37 @@ function App() {
           path="/backoffice/:section"
           element={staffGuard(
             <BackofficeRoute
+              mode="index"
+              canReadCompanies={canReadCompanies}
+              canCreateCompanies={canCreateCompanies}
+              canUpdateCompanies={canUpdateCompanies}
               canReadUsers={canReadUsers}
               canCreateUsers={canCreateUsers}
               canUpdateUsers={canUpdateUsers}
+              canDeleteUsers={canDeleteUsers}
               canReadTrackers={canReadTrackers}
               canUpdateTrackers={canUpdateTrackers}
               canCreateTrackers={canCreateTrackers}
+              canDeleteTrackers={canDeleteTrackers}
+            />
+          )}
+        />
+        <Route
+          path="/backoffice/:section/new"
+          element={staffGuard(
+            <BackofficeRoute
+              mode="create"
+              canReadCompanies={canReadCompanies}
+              canCreateCompanies={canCreateCompanies}
+              canUpdateCompanies={canUpdateCompanies}
+              canReadUsers={canReadUsers}
+              canCreateUsers={canCreateUsers}
+              canUpdateUsers={canUpdateUsers}
+              canDeleteUsers={canDeleteUsers}
+              canReadTrackers={canReadTrackers}
+              canUpdateTrackers={canUpdateTrackers}
+              canCreateTrackers={canCreateTrackers}
+              canDeleteTrackers={canDeleteTrackers}
             />
           )}
         />
@@ -239,12 +309,18 @@ function App() {
           path="/backoffice/:section/:entityId"
           element={staffGuard(
             <BackofficeRoute
+              mode="edit"
+              canReadCompanies={canReadCompanies}
+              canCreateCompanies={canCreateCompanies}
+              canUpdateCompanies={canUpdateCompanies}
               canReadUsers={canReadUsers}
               canCreateUsers={canCreateUsers}
               canUpdateUsers={canUpdateUsers}
+              canDeleteUsers={canDeleteUsers}
               canReadTrackers={canReadTrackers}
               canUpdateTrackers={canUpdateTrackers}
               canCreateTrackers={canCreateTrackers}
+              canDeleteTrackers={canDeleteTrackers}
             />
           )}
         />

--- a/track-app/src/components/Backoffice/index.tsx
+++ b/track-app/src/components/Backoffice/index.tsx
@@ -12,6 +12,7 @@ function toggleInArray(list: string[], value: string): string[] {
 }
 
 type ConfirmModalState = {
+  entityType: 'company' | 'user' | 'tracker'
   title: string
   description: string
   confirmLabel: string
@@ -259,8 +260,14 @@ function Backoffice({
     }
   }
 
-  const openDeleteModal = (title: string, description: string, onConfirm: () => Promise<void>) => {
+  const openDeleteModal = (
+    entityType: 'company' | 'user' | 'tracker',
+    title: string,
+    description: string,
+    onConfirm: () => Promise<void>
+  ) => {
     setConfirmState({
+      entityType,
       title,
       description,
       confirmLabel: t('ui.delete'),
@@ -374,6 +381,7 @@ function Backoffice({
           onEdit={canUpdateCompanies ? (company) => navigate(`/backoffice/companies/${company.id}`) : undefined}
           onDelete={canUpdateCompanies ? (company) => {
             openDeleteModal(
+              'company',
               t('backoffice.confirmDeleteTitle'),
               t('backoffice.confirmDeleteMessage', { entity: company.name }),
               () => deleteCompany(company.id)
@@ -390,6 +398,7 @@ function Backoffice({
           onEdit={canUpdateUsers ? (user) => navigate(`/backoffice/users/${user.id}`) : undefined}
           onDelete={canDeleteUsers ? (user) => {
             openDeleteModal(
+              'user',
               t('backoffice.confirmDeleteTitle'),
               t('backoffice.confirmDeleteMessage', { entity: user.email }),
               () => deleteUser(user.id)
@@ -414,6 +423,7 @@ function Backoffice({
           onDelete={canDeleteTrackers ? (tracker) => {
             const entity = tracker.alias || tracker.serialNumber
             openDeleteModal(
+              'tracker',
               t('backoffice.confirmDeleteTitle'),
               t('backoffice.confirmDeleteMessage', { entity }),
               () => deleteTracker(tracker.id)
@@ -726,7 +736,25 @@ function Backoffice({
       {confirmState && (
         <div className="fixed inset-0 z-[1400] flex items-center justify-center bg-black/45 p-4">
           <div className="w-full max-w-md rounded-2xl border bg-[var(--bg-surface)] p-5 shadow-2xl">
-            <h4 className="text-lg font-bold text-[var(--text-primary)]">{confirmState.title}</h4>
+            <div className="flex items-center gap-2">
+              <span className="text-xl" aria-hidden="true">
+                {confirmState.entityType === 'company'
+                  ? '🏢'
+                  : confirmState.entityType === 'user'
+                    ? '👤'
+                    : '🚚'}
+              </span>
+              <h4 className={`text-lg font-bold ${
+                confirmState.entityType === 'company'
+                  ? 'text-amber-600'
+                  : confirmState.entityType === 'user'
+                    ? 'text-sky-600'
+                    : 'text-rose-600'
+              }`}
+              >
+                {confirmState.title}
+              </h4>
+            </div>
             <p className="mt-2 text-sm text-[var(--text-secondary)]">{confirmState.description}</p>
             <div className="mt-5 flex justify-end gap-2">
               <button
@@ -739,7 +767,13 @@ function Backoffice({
               </button>
               <button
                 type="button"
-                className="rounded-full border border-red-700 bg-red-700 px-4 py-2 text-sm font-semibold text-white"
+                className={`rounded-full border px-4 py-2 text-sm font-semibold text-white ${
+                  confirmState.entityType === 'company'
+                    ? 'border-amber-700 bg-amber-700'
+                    : confirmState.entityType === 'user'
+                      ? 'border-sky-700 bg-sky-700'
+                      : 'border-red-700 bg-red-700'
+                }`}
                 onClick={submitConfirm}
                 disabled={confirmLoading}
               >

--- a/track-app/src/components/Backoffice/index.tsx
+++ b/track-app/src/components/Backoffice/index.tsx
@@ -8,31 +8,41 @@ import { useNavigate } from 'react-router-dom'
 import { TRACKER_EMOJIS } from '../../common/emoji-options'
 
 function toggleInArray(list: string[], value: string): string[] {
-  return list.includes(value)
-    ? list.filter(item => item !== value)
-    : [...list, value]
+  return list.includes(value) ? list.filter(item => item !== value) : [...list, value]
 }
 
 interface BackofficeProps {
   section: 'companies' | 'users' | 'trackers'
+  mode: 'index' | 'create' | 'edit'
   entityId?: string
+  canReadCompanies?: boolean
+  canCreateCompanies?: boolean
+  canUpdateCompanies?: boolean
   canReadUsers?: boolean
   canCreateUsers?: boolean
   canUpdateUsers?: boolean
+  canDeleteUsers?: boolean
   canReadTrackers?: boolean
   canUpdateTrackers?: boolean
   canCreateTrackers?: boolean
+  canDeleteTrackers?: boolean
 }
 
 function Backoffice({
   section,
+  mode,
   entityId,
+  canReadCompanies = true,
+  canCreateCompanies = true,
+  canUpdateCompanies = true,
   canReadUsers = true,
   canCreateUsers = true,
   canUpdateUsers = true,
+  canDeleteUsers = true,
   canReadTrackers = true,
   canUpdateTrackers = true,
-  canCreateTrackers = true
+  canCreateTrackers = true,
+  canDeleteTrackers = true
 }: BackofficeProps) {
   const { t } = useTranslation()
   const navigate = useNavigate()
@@ -46,11 +56,13 @@ function Backoffice({
   const isCompaniesSection = section === 'companies'
   const isUsersSection = section === 'users'
   const isTrackersSection = section === 'trackers'
-  const isDetailView = Boolean(entityId)
-  const canSeeUsersSection = canReadUsers || canCreateUsers || canUpdateUsers
-  const canSeeTrackersSection = canReadTrackers || canUpdateTrackers || canCreateTrackers
-  const shouldLoadUsers = isUsersSection && canReadUsers
-  const shouldLoadTrackers = isTrackersSection && canReadTrackers
+  const isIndexView = mode === 'index'
+  const isCreateView = mode === 'create'
+  const isEditView = mode === 'edit'
+  const canSeeUsersSection = canReadUsers || canCreateUsers || canUpdateUsers || canDeleteUsers
+  const canSeeTrackersSection = canReadTrackers || canCreateTrackers || canUpdateTrackers || canDeleteTrackers
+  const shouldLoadUsers = isUsersSection && canReadUsers && isIndexView
+  const shouldLoadTrackers = isTrackersSection && canReadTrackers && isIndexView
 
   const [usersPage, setUsersPage] = useState(1)
   const [trackersPage, setTrackersPage] = useState(1)
@@ -58,6 +70,8 @@ function Backoffice({
     companies,
     users,
     trackers,
+    companyDetail,
+    userDetail,
     trackerDetail,
     usersTotalCount,
     trackersTotalCount,
@@ -67,13 +81,23 @@ function Backoffice({
     createTracker,
     updateCompany,
     updateUser,
-    updateTracker
-  } = useBackoffice(usersPage, 20, shouldLoadUsers, trackersPage, 20, shouldLoadTrackers, isTrackersSection ? entityId : undefined)
-  const [companyForm, setCompanyForm] = useState({
-    name: '',
-    active: true,
-    featureKeys: [...FEATURE_KEYS]
-  })
+    updateTracker,
+    deleteCompany,
+    deleteUser,
+    deleteTracker
+  } = useBackoffice(
+    usersPage,
+    20,
+    shouldLoadUsers,
+    trackersPage,
+    20,
+    shouldLoadTrackers,
+    isTrackersSection && isEditView ? entityId : undefined,
+    isCompaniesSection && isEditView ? entityId : undefined,
+    isUsersSection && isEditView ? entityId : undefined
+  )
+
+  const [companyForm, setCompanyForm] = useState({ name: '', active: true, featureKeys: [...FEATURE_KEYS] })
   const [userForm, setUserForm] = useState({
     name: '',
     surname: '',
@@ -84,29 +108,60 @@ function Backoffice({
     companyId: '',
     permissionKeys: permissionTemplateForRole('admin')
   })
-  const [trackerForm, setTrackerForm] = useState({
-    serialNumber: '',
-    alias: '',
-    emoji: '🚚',
-    companyId: ''
+  const [trackerForm, setTrackerForm] = useState({ serialNumber: '', alias: '', emoji: '🚚', companyId: '' })
+
+  const [companyEdit, setCompanyEdit] = useState({ name: '', slug: '', active: true, featureKeys: [] as string[] })
+  const [userEdit, setUserEdit] = useState({
+    name: '',
+    surname: '',
+    email: '',
+    language: 'en',
+    role: 'viewer',
+    companyId: '',
+    permissionKeys: [] as string[]
   })
-  const [selectedCompanyId, setSelectedCompanyId] = useState<string>('')
-  const [selectedUserId, setSelectedUserId] = useState<string>('')
   const [trackerAliasEdit, setTrackerAliasEdit] = useState('')
   const [trackerEmojiEdit, setTrackerEmojiEdit] = useState('🚚')
+
+  const companyOptions = useMemo(
+    () => companies.map((company) => ({ id: company.id, label: `${company.name} (${company.slug})` })),
+    [companies]
+  )
+
+  useEffect(() => {
+    if (!companyDetail) return
+    setCompanyEdit({
+      name: companyDetail.name,
+      slug: companyDetail.slug,
+      active: companyDetail.active,
+      featureKeys: [...companyDetail.featureKeys]
+    })
+  }, [companyDetail?.id, companyDetail?.name, companyDetail?.slug, companyDetail?.active, companyDetail?.featureKeys])
+
+  useEffect(() => {
+    if (!userDetail) return
+    setUserEdit({
+      name: userDetail.name,
+      surname: userDetail.surname,
+      email: userDetail.email,
+      language: userDetail.language || 'en',
+      role: userDetail.role,
+      companyId: userDetail.companyId || '',
+      permissionKeys: [...userDetail.permissionKeys]
+    })
+  }, [userDetail?.id, userDetail?.name, userDetail?.surname, userDetail?.email, userDetail?.language, userDetail?.role, userDetail?.companyId, userDetail?.permissionKeys])
+
+  useEffect(() => {
+    if (!trackerDetail) return
+    setTrackerAliasEdit(trackerDetail.alias || '')
+    setTrackerEmojiEdit(trackerDetail.emoji || '🚚')
+  }, [trackerDetail?.id, trackerDetail?.alias, trackerDetail?.emoji])
+
   const COMPANY_COLUMNS: Column<BackofficeCompany>[] = [
     { key: 'name', label: t('auth.name') },
     { key: 'slug', label: t('backoffice.slug') },
-    {
-      key: 'active',
-      label: t('backoffice.active'),
-      render: (row) => (row.active ? t('backoffice.yes') : t('backoffice.no'))
-    },
-    {
-      key: 'featureKeys',
-      label: t('backoffice.features'),
-      render: (row) => row.featureKeys.join(', ')
-    }
+    { key: 'active', label: t('backoffice.active'), render: (row) => (row.active ? t('backoffice.yes') : t('backoffice.no')) },
+    { key: 'featureKeys', label: t('backoffice.features'), render: (row) => row.featureKeys.join(', ') }
   ]
   const USER_COLUMNS: Column<BackofficeUser>[] = [
     { key: 'name', label: t('auth.name') },
@@ -114,38 +169,19 @@ function Backoffice({
     { key: 'email', label: t('auth.email') },
     { key: 'language', label: t('backoffice.language') },
     { key: 'role', label: t('backoffice.role') },
-    { key: 'companyId', label: t('backoffice.companyId') },
-    {
-      key: 'permissionKeys',
-      label: t('backoffice.permissions'),
-      render: (row) => row.permissionKeys.join(', ')
-    }
+    { key: 'companyId', label: t('backoffice.companyId') }
   ]
   const TRACKER_COLUMNS: Column<BackofficeTracker>[] = [
-    {
-      key: 'emoji',
-      label: t('ui.emoji'),
-      render: (row) => row.emoji || '🚚'
-    },
+    { key: 'emoji', label: t('ui.emoji'), render: (row) => row.emoji || '🚚' },
     { key: 'serialNumber', label: t('trackers.serialNumber') },
     { key: 'alias', label: t('ui.alias') }
   ]
 
-  const companyOptions = useMemo(
-    () => companies.map((company) => ({ id: company.id, label: `${company.name} (${company.slug})` })),
-    [companies]
-  )
-
   const onCreateCompany = async (e: React.FormEvent) => {
     e.preventDefault()
     await createCompany(companyForm.name, companyForm.active, companyForm.featureKeys)
-    setCompanyForm({
-      name: '',
-      active: true,
-      featureKeys: [...FEATURE_KEYS]
-    })
+    navigate('/backoffice/companies')
   }
-
   const onCreateUser = async (e: React.FormEvent) => {
     e.preventDefault()
     await createUser({
@@ -158,18 +194,8 @@ function Backoffice({
       companyId: userForm.companyId,
       permissionKeys: userForm.permissionKeys
     })
-    setUserForm({
-      name: '',
-      surname: '',
-      email: '',
-      password: '',
-      language: 'en',
-      role: 'admin',
-      companyId: '',
-      permissionKeys: permissionTemplateForRole('admin')
-    })
+    navigate('/backoffice/users')
   }
-
   const onCreateTracker = async (e: React.FormEvent) => {
     e.preventDefault()
     await createTracker({
@@ -178,92 +204,18 @@ function Backoffice({
       emoji: trackerForm.emoji,
       companyId: trackerForm.companyId
     })
-    setTrackerForm({
-      serialNumber: '',
-      alias: '',
-      emoji: '🚚',
-      companyId: ''
-    })
-  }
-
-  const selectedCompany = useMemo(
-    () => companies.find(company => company.id === selectedCompanyId) || null,
-    [companies, selectedCompanyId]
-  )
-
-  const selectedUser = useMemo(
-    () => users.find(user => user.id === selectedUserId) || null,
-    [users, selectedUserId]
-  )
-
-  const [companyEdit, setCompanyEdit] = useState({
-    name: '',
-    slug: '',
-    active: true,
-    featureKeys: [] as string[]
-  })
-
-  const [userEdit, setUserEdit] = useState({
-    name: '',
-    surname: '',
-    email: '',
-    language: 'en',
-    role: 'viewer',
-    companyId: '',
-    permissionKeys: [] as string[]
-  })
-
-  const fillCompanyEdit = (companyId: string) => {
-    const company = companies.find(item => item.id === companyId)
-    if (!company) return
-    setCompanyEdit({
-      name: company.name,
-      slug: company.slug,
-      active: company.active,
-      featureKeys: [...company.featureKeys]
-    })
-  }
-
-  const fillUserEdit = (userId: string) => {
-    const user = users.find(item => item.id === userId)
-    if (!user) return
-    setUserEdit({
-      name: user.name,
-      surname: user.surname,
-      email: user.email,
-      language: user.language || 'en',
-      role: user.role,
-      companyId: user.companyId || '',
-      permissionKeys: [...user.permissionKeys]
-    })
-  }
-
-  const onPickCompany = (companyId: string) => {
-    if (!companyId) {
-      navigate('/backoffice/companies')
-      return
-    }
-    navigate(`/backoffice/companies/${companyId}`)
-  }
-
-  const onPickUser = (userId: string) => {
-    if (!userId) {
-      navigate('/backoffice/users')
-      return
-    }
-    navigate(`/backoffice/users/${userId}`)
+    navigate('/backoffice/trackers')
   }
 
   const onUpdateCompany = async (e: React.FormEvent) => {
     e.preventDefault()
-    if (!selectedCompany) return
-    await updateCompany(selectedCompany.id, companyEdit.name, companyEdit.slug, companyEdit.active, companyEdit.featureKeys)
+    if (!companyDetail?.id) return
+    await updateCompany(companyDetail.id, companyEdit.name, companyEdit.slug, companyEdit.active, companyEdit.featureKeys)
   }
-
   const onUpdateUser = async (e: React.FormEvent) => {
     e.preventDefault()
-    if (!selectedUser) return
-    await updateUser(selectedUser.id, {
+    if (!userDetail?.id) return
+    await updateUser(userDetail.id, {
       name: userEdit.name,
       surname: userEdit.surname,
       email: userEdit.email,
@@ -276,81 +228,121 @@ function Backoffice({
   const onUpdateTracker = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!trackerDetail?.id || !trackerAliasEdit.trim()) return
-    await updateTracker(trackerDetail.id, {
-      alias: trackerAliasEdit.trim(),
-      emoji: trackerEmojiEdit
-    })
+    await updateTracker(trackerDetail.id, { alias: trackerAliasEdit.trim(), emoji: trackerEmojiEdit })
   }
 
-  useEffect(() => {
-    if (!isCompaniesSection) return
-    const nextCompanyId = entityId || ''
-    if (nextCompanyId !== selectedCompanyId) setSelectedCompanyId(nextCompanyId)
-    if (nextCompanyId) fillCompanyEdit(nextCompanyId)
-  }, [isCompaniesSection, entityId, selectedCompanyId, companies])
+  const askDelete = (label: string) => window.confirm(`${t('ui.delete')} "${label}"?`)
 
-  useEffect(() => {
-    if (!isUsersSection) return
-    const nextUserId = entityId || ''
-    if (nextUserId !== selectedUserId) setSelectedUserId(nextUserId)
-    if (nextUserId) fillUserEdit(nextUserId)
-  }, [isUsersSection, entityId, selectedUserId, users])
-
-  useEffect(() => {
-    if (!isTrackersSection) return
-    setTrackerAliasEdit(trackerDetail?.alias || '')
-    setTrackerEmojiEdit(trackerDetail?.emoji || '🚚')
-  }, [isTrackersSection, trackerDetail?.id, trackerDetail?.alias, trackerDetail?.emoji])
-
-  return (
-    <PageShell title={t('backoffice.title')}>
-      {loading && <p className="text-center text-[var(--text-muted)]">{t('backoffice.loading')}</p>}
-
-      <div className="mb-6 flex flex-wrap gap-2">
+  const renderSectionTabs = () => (
+    <div className="mb-6 flex flex-wrap gap-2">
+      <button
+        className={`rounded-full border px-3 py-1.5 text-sm font-medium ${isCompaniesSection ? 'bg-[var(--bg-glass-strong)] text-[var(--text-primary)]' : 'bg-[var(--bg-glass)] text-[var(--text-secondary)]'}`}
+        onClick={() => navigate('/backoffice/companies')}
+        type="button"
+      >
+        {t('backoffice.companies')}
+      </button>
+      {canSeeUsersSection && (
         <button
-          className={`rounded-full border px-3 py-1.5 text-sm font-medium ${isCompaniesSection ? 'bg-[var(--bg-glass-strong)] text-[var(--text-primary)]' : 'bg-[var(--bg-glass)] text-[var(--text-secondary)]'}`}
-          onClick={() => navigate('/backoffice/companies')}
+          className={`rounded-full border px-3 py-1.5 text-sm font-medium ${isUsersSection ? 'bg-[var(--bg-glass-strong)] text-[var(--text-primary)]' : 'bg-[var(--bg-glass)] text-[var(--text-secondary)]'}`}
+          onClick={() => navigate('/backoffice/users')}
           type="button"
         >
-          {t('backoffice.companies')}
+          {t('backoffice.users')}
         </button>
-        {canSeeUsersSection && (
-          <button
-            className={`rounded-full border px-3 py-1.5 text-sm font-medium ${isUsersSection ? 'bg-[var(--bg-glass-strong)] text-[var(--text-primary)]' : 'bg-[var(--bg-glass)] text-[var(--text-secondary)]'}`}
-            onClick={() => navigate('/backoffice/users')}
-            type="button"
-          >
-            {t('backoffice.users')}
-          </button>
-        )}
-        {canSeeTrackersSection && (
-          <button
-            className={`rounded-full border px-3 py-1.5 text-sm font-medium ${isTrackersSection ? 'bg-[var(--bg-glass-strong)] text-[var(--text-primary)]' : 'bg-[var(--bg-glass)] text-[var(--text-secondary)]'}`}
-            onClick={() => navigate('/backoffice/trackers')}
-            type="button"
-          >
-            {t('trackers.title')}
-          </button>
-        )}
-      </div>
-      {isDetailView && (
-        <div className="mb-6">
-          <button
-            className="rounded-full border px-3 py-1.5 text-sm font-medium bg-[var(--bg-glass)] text-[var(--text-primary)]"
-            onClick={() => navigate(`/backoffice/${section}`)}
-            type="button"
-          >
-            {t('ui.back')}
-          </button>
-        </div>
       )}
-      <div className="space-y-8">
+      {canSeeTrackersSection && (
+        <button
+          className={`rounded-full border px-3 py-1.5 text-sm font-medium ${isTrackersSection ? 'bg-[var(--bg-glass-strong)] text-[var(--text-primary)]' : 'bg-[var(--bg-glass)] text-[var(--text-secondary)]'}`}
+          onClick={() => navigate('/backoffice/trackers')}
+          type="button"
+        >
+          {t('trackers.title')}
+        </button>
+      )}
+    </div>
+  )
 
-      {isCompaniesSection && !isDetailView && (
-      <>
-      <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
-        <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.createCompany')}</h3>
+  const renderBack = () => (
+    <div className="mb-6">
+      <button
+        className="rounded-full border px-3 py-1.5 text-sm font-medium bg-[var(--bg-glass)] text-[var(--text-primary)]"
+        onClick={() => navigate(`/backoffice/${section}`)}
+        type="button"
+      >
+        {t('ui.back')}
+      </button>
+    </div>
+  )
+
+  const renderIndexActions = () => (
+    <div className="mb-6 flex justify-end">
+      {isCompaniesSection && canCreateCompanies && (
+        <button className={primaryButtonClass} type="button" onClick={() => navigate('/backoffice/companies/new')}>{t('backoffice.createCompany')}</button>
+      )}
+      {isUsersSection && canCreateUsers && (
+        <button className={primaryButtonClass} type="button" onClick={() => navigate('/backoffice/users/new')}>{t('backoffice.createUser')}</button>
+      )}
+      {isTrackersSection && canCreateTrackers && (
+        <button className={primaryButtonClass} type="button" onClick={() => navigate('/backoffice/trackers/new')}>{t('backoffice.createTracker')}</button>
+      )}
+    </div>
+  )
+
+  const renderIndex = () => (
+    <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
+      {isCompaniesSection && (
+        <DataTable
+          columns={COMPANY_COLUMNS}
+          rows={companies}
+          emptyMessage={t('backoffice.noCompanies')}
+          variant="flat"
+          onEdit={canUpdateCompanies ? (company) => navigate(`/backoffice/companies/${company.id}`) : undefined}
+          onDelete={canUpdateCompanies ? async (company) => { if (askDelete(company.name)) await deleteCompany(company.id) } : undefined}
+        />
+      )}
+      {isUsersSection && (
+        <DataTable
+          columns={USER_COLUMNS}
+          rows={users}
+          emptyMessage={t('backoffice.noUsers')}
+          variant="flat"
+          onEdit={canUpdateUsers ? (user) => navigate(`/backoffice/users/${user.id}`) : undefined}
+          onDelete={canDeleteUsers ? async (user) => { if (askDelete(user.email)) await deleteUser(user.id) } : undefined}
+          pageSize={20}
+          serverPagination={{
+            enabled: true,
+            currentPage: usersPage,
+            totalCount: usersTotalCount,
+            onPageChange: setUsersPage
+          }}
+        />
+      )}
+      {isTrackersSection && (
+        <DataTable
+          columns={TRACKER_COLUMNS}
+          rows={trackers}
+          emptyMessage={t('trackers.empty')}
+          variant="flat"
+          onEdit={canUpdateTrackers ? (tracker) => navigate(`/backoffice/trackers/${tracker.id}`) : undefined}
+          onDelete={canDeleteTrackers ? async (tracker) => { if (askDelete(tracker.alias || tracker.serialNumber)) await deleteTracker(tracker.id) } : undefined}
+          pageSize={20}
+          serverPagination={{
+            enabled: true,
+            currentPage: trackersPage,
+            totalCount: trackersTotalCount,
+            onPageChange: setTrackersPage
+          }}
+        />
+      )}
+    </section>
+  )
+
+  const renderCreate = () => (
+    <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
+      {isCompaniesSection && canCreateCompanies && (
         <form onSubmit={onCreateCompany}>
+          <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.createCompany')}</h3>
           <div className="mb-4">
             <label className={labelClass}>{t('auth.name')}</label>
             <input className={inputClass} value={companyForm.name} onChange={(e) => setCompanyForm(prev => ({ ...prev, name: e.target.value }))} required />
@@ -366,11 +358,7 @@ function Backoffice({
             <div className={checkboxesWrapClass}>
               {FEATURE_KEYS.map((feature) => (
                 <label key={feature} className={checkboxClass}>
-                  <input
-                    type="checkbox"
-                    checked={companyForm.featureKeys.includes(feature)}
-                    onChange={() => setCompanyForm(prev => ({ ...prev, featureKeys: toggleInArray(prev.featureKeys, feature) }))}
-                  />
+                  <input type="checkbox" checked={companyForm.featureKeys.includes(feature)} onChange={() => setCompanyForm(prev => ({ ...prev, featureKeys: toggleInArray(prev.featureKeys, feature) }))} />
                   {feature}
                 </label>
               ))}
@@ -378,25 +366,10 @@ function Backoffice({
           </div>
           <button className={`${primaryButtonClass} mt-2`} type="submit">{t('backoffice.createCompany')}</button>
         </form>
-      </section>
-
-      <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
-        <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.companies')}</h3>
-        <DataTable
-          columns={COMPANY_COLUMNS}
-          rows={companies}
-          emptyMessage={t('backoffice.noCompanies')}
-          variant="flat"
-          onEdit={(company) => navigate(`/backoffice/companies/${company.id}`)}
-        />
-      </section>
-      </>
       )}
-
-      {isUsersSection && !isDetailView && canCreateUsers && (
-      <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
-        <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.createUser')}</h3>
+      {isUsersSection && canCreateUsers && (
         <form onSubmit={onCreateUser}>
+          <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.createUser')}</h3>
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             <div>
               <label className={labelClass}>{t('auth.name')}</label>
@@ -416,11 +389,7 @@ function Backoffice({
             </div>
             <div>
               <label className={labelClass}>{t('backoffice.language')}</label>
-              <select
-                className={inputClass}
-                value={userForm.language}
-                onChange={(e) => setUserForm(prev => ({ ...prev, language: e.target.value }))}
-              >
+              <select className={inputClass} value={userForm.language} onChange={(e) => setUserForm(prev => ({ ...prev, language: e.target.value }))}>
                 <option value="en">{t('ui.languageEnglish')}</option>
                 <option value="es">{t('ui.languageSpanish')}</option>
                 <option value="ca">{t('ui.languageCatalan')}</option>
@@ -428,14 +397,10 @@ function Backoffice({
             </div>
             <div>
               <label className={labelClass}>{t('backoffice.role')}</label>
-              <select
-                className={inputClass}
-                value={userForm.role}
-                onChange={(e) => {
-                  const role = e.target.value
-                  setUserForm(prev => ({ ...prev, role, permissionKeys: permissionTemplateForRole(role) }))
-                }}
-              >
+              <select className={inputClass} value={userForm.role} onChange={(e) => {
+                const role = e.target.value
+                setUserForm(prev => ({ ...prev, role, permissionKeys: permissionTemplateForRole(role) }))
+              }}>
                 <option value="staff">{t('roles.staff')}</option>
                 <option value="owner">{t('roles.owner')}</option>
                 <option value="admin">{t('roles.admin')}</option>
@@ -457,11 +422,7 @@ function Backoffice({
               <div className={checkboxesWrapClass}>
                 {PERMISSION_KEYS.map((permission) => (
                   <label key={permission} className={checkboxClass}>
-                    <input
-                      type="checkbox"
-                      checked={userForm.permissionKeys.includes(permission)}
-                      onChange={() => setUserForm(prev => ({ ...prev, permissionKeys: toggleInArray(prev.permissionKeys, permission) }))}
-                    />
+                    <input type="checkbox" checked={userForm.permissionKeys.includes(permission)} onChange={() => setUserForm(prev => ({ ...prev, permissionKeys: toggleInArray(prev.permissionKeys, permission) }))} />
                     {permission}
                   </label>
                 ))}
@@ -470,317 +431,22 @@ function Backoffice({
           </div>
           <button className={`${primaryButtonClass} mt-6`} type="submit">{t('backoffice.createUser')}</button>
         </form>
-      </section>
       )}
-
-      {isCompaniesSection && !isDetailView && (
-      <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
-        <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.editCompany')}</h3>
-        <div className="mb-4">
-          <label className={labelClass}>{t('backoffice.company')}</label>
-          <select className={inputClass} value={selectedCompanyId} onChange={(e) => onPickCompany(e.target.value)}>
-            <option value="">{t('backoffice.selectCompanyShort')}</option>
-            {companyOptions.map((company) => (
-              <option key={company.id} value={company.id}>{company.label}</option>
-            ))}
-          </select>
-        </div>
-        {selectedCompany && (
-          <form onSubmit={onUpdateCompany}>
-            <div className="mb-4">
-              <label className={labelClass}>{t('auth.name')}</label>
-              <input className={inputClass} value={companyEdit.name} onChange={(e) => setCompanyEdit(prev => ({ ...prev, name: e.target.value }))} required />
-            </div>
-            <div className="mb-4">
-              <label className={labelClass}>{t('backoffice.slug')}</label>
-              <input className={inputClass} value={companyEdit.slug} readOnly />
-            </div>
-            <div className="mb-4">
-              <label className="inline-flex items-center gap-2 text-sm text-[var(--text-primary)]">
-                <input type="checkbox" checked={companyEdit.active} onChange={(e) => setCompanyEdit(prev => ({ ...prev, active: e.target.checked }))} />
-                {t('backoffice.active')}
-              </label>
-            </div>
-            <div className="mb-4">
-              <label className={labelClass}>{t('backoffice.features')}</label>
-              <div className={checkboxesWrapClass}>
-                {FEATURE_KEYS.map((feature) => (
-                  <label key={feature} className={checkboxClass}>
-                    <input
-                      type="checkbox"
-                      checked={companyEdit.featureKeys.includes(feature)}
-                      onChange={() => setCompanyEdit(prev => ({ ...prev, featureKeys: toggleInArray(prev.featureKeys, feature) }))}
-                    />
-                    {feature}
-                  </label>
-                ))}
-              </div>
-            </div>
-            <button className={`${primaryButtonClass} mt-2`} type="submit">{t('backoffice.updateCompany')}</button>
-          </form>
-        )}
-      </section>
-      )}
-
-      {isUsersSection && !isDetailView && canReadUsers && canUpdateUsers && (
-      <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
-        <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.editUser')}</h3>
-        <div className="mb-4">
-          <label className={labelClass}>{t('backoffice.users')}</label>
-          <select className={inputClass} value={selectedUserId} onChange={(e) => onPickUser(e.target.value)}>
-            <option value="">{t('backoffice.selectUser')}</option>
-            {users.map((user) => (
-              <option key={user.id} value={user.id}>{user.email}</option>
-            ))}
-          </select>
-        </div>
-        {selectedUser && (
-          <form onSubmit={onUpdateUser}>
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-              <div>
-                <label className={labelClass}>{t('auth.name')}</label>
-                <input className={inputClass} value={userEdit.name} onChange={(e) => setUserEdit(prev => ({ ...prev, name: e.target.value }))} required />
-              </div>
-              <div>
-                <label className={labelClass}>{t('auth.surname')}</label>
-                <input className={inputClass} value={userEdit.surname} onChange={(e) => setUserEdit(prev => ({ ...prev, surname: e.target.value }))} required />
-              </div>
-              <div>
-                <label className={labelClass}>{t('auth.email')}</label>
-                <input className={inputClass} type="email" value={userEdit.email} onChange={(e) => setUserEdit(prev => ({ ...prev, email: e.target.value }))} required />
-              </div>
-              <div>
-                <label className={labelClass}>{t('backoffice.language')}</label>
-                <select
-                  className={inputClass}
-                  value={userEdit.language}
-                  onChange={(e) => setUserEdit(prev => ({ ...prev, language: e.target.value }))}
-                >
-                  <option value="en">{t('ui.languageEnglish')}</option>
-                  <option value="es">{t('ui.languageSpanish')}</option>
-                  <option value="ca">{t('ui.languageCatalan')}</option>
-                </select>
-              </div>
-              <div>
-                <label className={labelClass}>{t('backoffice.role')}</label>
-                <select
-                  className={inputClass}
-                  value={userEdit.role}
-                  onChange={(e) => {
-                    const role = e.target.value
-                    setUserEdit(prev => ({ ...prev, role, permissionKeys: permissionTemplateForRole(role) }))
-                  }}
-                >
-                  <option value="staff">{t('roles.staff')}</option>
-                  <option value="owner">{t('roles.owner')}</option>
-                  <option value="admin">{t('roles.admin')}</option>
-                  <option value="dispatcher">{t('roles.dispatcher')}</option>
-                  <option value="viewer">{t('roles.viewer')}</option>
-                </select>
-              </div>
-              <div>
-                <label className={labelClass}>{t('backoffice.company')}</label>
-                <select className={inputClass} value={userEdit.companyId} onChange={(e) => setUserEdit(prev => ({ ...prev, companyId: e.target.value }))}>
-                  <option value="">{t('backoffice.selectCompanyShort')}</option>
-                  {companyOptions.map((company) => (
-                    <option key={company.id} value={company.id}>{company.label}</option>
-                  ))}
-                </select>
-              </div>
-              <div className="md:col-span-2">
-                <label className={labelClass}>{t('backoffice.permissions')}</label>
-                <div className={checkboxesWrapClass}>
-                  {PERMISSION_KEYS.map((permission) => (
-                    <label key={permission} className={checkboxClass}>
-                      <input
-                        type="checkbox"
-                        checked={userEdit.permissionKeys.includes(permission)}
-                        onChange={() => setUserEdit(prev => ({ ...prev, permissionKeys: toggleInArray(prev.permissionKeys, permission) }))}
-                      />
-                      {permission}
-                    </label>
-                  ))}
-                </div>
-              </div>
-            </div>
-            <button className={`${primaryButtonClass} mt-6`} type="submit">{t('backoffice.updateUser')}</button>
-          </form>
-        )}
-      </section>
-      )}
-
-      {isUsersSection && !isDetailView && canReadUsers && (
-      <section>
-        <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.users')}</h3>
-        <DataTable
-          columns={USER_COLUMNS}
-          rows={users}
-          emptyMessage={t('backoffice.noUsers')}
-          variant="flat"
-          onEdit={(user) => navigate(`/backoffice/users/${user.id}`)}
-          pageSize={20}
-          serverPagination={{
-            enabled: true,
-            currentPage: usersPage,
-            totalCount: usersTotalCount,
-            onPageChange: setUsersPage
-          }}
-        />
-      </section>
-      )}
-
-      {isCompaniesSection && isDetailView && (
-      <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
-        <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.editCompany')}</h3>
-        {selectedCompany ? (
-          <form onSubmit={onUpdateCompany}>
-            <div className="mb-4">
-              <label className={labelClass}>{t('auth.name')}</label>
-              <input className={inputClass} value={companyEdit.name} onChange={(e) => setCompanyEdit(prev => ({ ...prev, name: e.target.value }))} required />
-            </div>
-            <div className="mb-4">
-              <label className={labelClass}>{t('backoffice.slug')}</label>
-              <input className={inputClass} value={companyEdit.slug} readOnly />
-            </div>
-            <div className="mb-4">
-              <label className="inline-flex items-center gap-2 text-sm text-[var(--text-primary)]">
-                <input type="checkbox" checked={companyEdit.active} onChange={(e) => setCompanyEdit(prev => ({ ...prev, active: e.target.checked }))} />
-                {t('backoffice.active')}
-              </label>
-            </div>
-            <div className="mb-4">
-              <label className={labelClass}>{t('backoffice.features')}</label>
-              <div className={checkboxesWrapClass}>
-                {FEATURE_KEYS.map((feature) => (
-                  <label key={feature} className={checkboxClass}>
-                    <input
-                      type="checkbox"
-                      checked={companyEdit.featureKeys.includes(feature)}
-                      onChange={() => setCompanyEdit(prev => ({ ...prev, featureKeys: toggleInArray(prev.featureKeys, feature) }))}
-                    />
-                    {feature}
-                  </label>
-                ))}
-              </div>
-            </div>
-            <button className={`${primaryButtonClass} mt-2`} type="submit">{t('backoffice.updateCompany')}</button>
-          </form>
-        ) : (
-          <p className="text-sm text-[var(--text-muted)]">{t('ui.loading')}</p>
-        )}
-      </section>
-      )}
-
-      {isUsersSection && isDetailView && canReadUsers && canUpdateUsers && (
-      <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
-        <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.editUser')}</h3>
-        {selectedUser ? (
-          <form onSubmit={onUpdateUser}>
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-              <div>
-                <label className={labelClass}>{t('auth.name')}</label>
-                <input className={inputClass} value={userEdit.name} onChange={(e) => setUserEdit(prev => ({ ...prev, name: e.target.value }))} required />
-              </div>
-              <div>
-                <label className={labelClass}>{t('auth.surname')}</label>
-                <input className={inputClass} value={userEdit.surname} onChange={(e) => setUserEdit(prev => ({ ...prev, surname: e.target.value }))} required />
-              </div>
-              <div>
-                <label className={labelClass}>{t('auth.email')}</label>
-                <input className={inputClass} type="email" value={userEdit.email} onChange={(e) => setUserEdit(prev => ({ ...prev, email: e.target.value }))} required />
-              </div>
-              <div>
-                <label className={labelClass}>{t('backoffice.language')}</label>
-                <select
-                  className={inputClass}
-                  value={userEdit.language}
-                  onChange={(e) => setUserEdit(prev => ({ ...prev, language: e.target.value }))}
-                >
-                  <option value="en">{t('ui.languageEnglish')}</option>
-                  <option value="es">{t('ui.languageSpanish')}</option>
-                  <option value="ca">{t('ui.languageCatalan')}</option>
-                </select>
-              </div>
-              <div>
-                <label className={labelClass}>{t('backoffice.role')}</label>
-                <select
-                  className={inputClass}
-                  value={userEdit.role}
-                  onChange={(e) => {
-                    const role = e.target.value
-                    setUserEdit(prev => ({ ...prev, role, permissionKeys: permissionTemplateForRole(role) }))
-                  }}
-                >
-                  <option value="staff">{t('roles.staff')}</option>
-                  <option value="owner">{t('roles.owner')}</option>
-                  <option value="admin">{t('roles.admin')}</option>
-                  <option value="dispatcher">{t('roles.dispatcher')}</option>
-                  <option value="viewer">{t('roles.viewer')}</option>
-                </select>
-              </div>
-              <div>
-                <label className={labelClass}>{t('backoffice.company')}</label>
-                <select className={inputClass} value={userEdit.companyId} onChange={(e) => setUserEdit(prev => ({ ...prev, companyId: e.target.value }))}>
-                  <option value="">{t('backoffice.selectCompanyShort')}</option>
-                  {companyOptions.map((company) => (
-                    <option key={company.id} value={company.id}>{company.label}</option>
-                  ))}
-                </select>
-              </div>
-              <div className="md:col-span-2">
-                <label className={labelClass}>{t('backoffice.permissions')}</label>
-                <div className={checkboxesWrapClass}>
-                  {PERMISSION_KEYS.map((permission) => (
-                    <label key={permission} className={checkboxClass}>
-                      <input
-                        type="checkbox"
-                        checked={userEdit.permissionKeys.includes(permission)}
-                        onChange={() => setUserEdit(prev => ({ ...prev, permissionKeys: toggleInArray(prev.permissionKeys, permission) }))}
-                      />
-                      {permission}
-                    </label>
-                  ))}
-                </div>
-              </div>
-            </div>
-            <button className={`${primaryButtonClass} mt-6`} type="submit">{t('backoffice.updateUser')}</button>
-          </form>
-        ) : (
-          <p className="text-sm text-[var(--text-muted)]">{t('ui.loading')}</p>
-        )}
-      </section>
-      )}
-
-      {isTrackersSection && !isDetailView && canCreateTrackers && (
-      <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
-        <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.createTracker')}</h3>
+      {isTrackersSection && canCreateTrackers && (
         <form onSubmit={onCreateTracker}>
+          <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.createTracker')}</h3>
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             <div>
               <label className={labelClass}>{t('trackers.serialNumber')}</label>
-              <input
-                className={inputClass}
-                value={trackerForm.serialNumber}
-                onChange={(e) => setTrackerForm(prev => ({ ...prev, serialNumber: e.target.value }))}
-                required
-              />
+              <input className={inputClass} value={trackerForm.serialNumber} onChange={(e) => setTrackerForm(prev => ({ ...prev, serialNumber: e.target.value }))} required />
             </div>
             <div>
               <label className={labelClass}>{t('ui.alias')}</label>
-              <input
-                className={inputClass}
-                value={trackerForm.alias}
-                onChange={(e) => setTrackerForm(prev => ({ ...prev, alias: e.target.value }))}
-                placeholder={t('ui.optional')}
-              />
+              <input className={inputClass} value={trackerForm.alias} onChange={(e) => setTrackerForm(prev => ({ ...prev, alias: e.target.value }))} placeholder={t('ui.optional')} />
             </div>
             <div>
               <label className={labelClass}>{t('ui.emoji')}</label>
-              <select
-                className={inputClass}
-                value={trackerForm.emoji}
-                onChange={(e) => setTrackerForm(prev => ({ ...prev, emoji: e.target.value }))}
-              >
+              <select className={inputClass} value={trackerForm.emoji} onChange={(e) => setTrackerForm(prev => ({ ...prev, emoji: e.target.value }))}>
                 {TRACKER_EMOJIS.map((option) => (
                   <option key={option.value} value={option.value}>{option.value} {option.label}</option>
                 ))}
@@ -788,12 +454,7 @@ function Backoffice({
             </div>
             <div>
               <label className={labelClass}>{t('backoffice.company')}</label>
-              <select
-                className={inputClass}
-                value={trackerForm.companyId}
-                onChange={(e) => setTrackerForm(prev => ({ ...prev, companyId: e.target.value }))}
-                required
-              >
+              <select className={inputClass} value={trackerForm.companyId} onChange={(e) => setTrackerForm(prev => ({ ...prev, companyId: e.target.value }))} required>
                 <option value="">{t('backoffice.selectCompany')}</option>
                 {companyOptions.map((company) => (
                   <option key={company.id} value={company.id}>{company.label}</option>
@@ -803,68 +464,153 @@ function Backoffice({
           </div>
           <button className={`${primaryButtonClass} mt-6`} type="submit">{t('backoffice.createTracker')}</button>
         </form>
-      </section>
       )}
+    </section>
+  )
 
-      {isTrackersSection && !isDetailView && canReadTrackers && (
-      <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
-        <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('trackers.title')}</h3>
-        <DataTable
-          columns={TRACKER_COLUMNS}
-          rows={trackers}
-          emptyMessage={t('trackers.empty')}
-          variant="flat"
-          onEdit={(tracker) => navigate(`/backoffice/trackers/${tracker.id}`)}
-          pageSize={20}
-          serverPagination={{
-            enabled: true,
-            currentPage: trackersPage,
-            totalCount: trackersTotalCount,
-            onPageChange: setTrackersPage
-          }}
-        />
-      </section>
+  const renderEdit = () => (
+    <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
+      {isCompaniesSection && canUpdateCompanies && (
+        <>
+          <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.editCompany')}</h3>
+          {companyDetail ? (
+            <form onSubmit={onUpdateCompany}>
+              <div className="mb-4">
+                <label className={labelClass}>{t('auth.name')}</label>
+                <input className={inputClass} value={companyEdit.name} onChange={(e) => setCompanyEdit(prev => ({ ...prev, name: e.target.value }))} required />
+              </div>
+              <div className="mb-4">
+                <label className={labelClass}>{t('backoffice.slug')}</label>
+                <input className={inputClass} value={companyEdit.slug} readOnly />
+              </div>
+              <div className="mb-4">
+                <label className="inline-flex items-center gap-2 text-sm text-[var(--text-primary)]">
+                  <input type="checkbox" checked={companyEdit.active} onChange={(e) => setCompanyEdit(prev => ({ ...prev, active: e.target.checked }))} />
+                  {t('backoffice.active')}
+                </label>
+              </div>
+              <div className="mb-4">
+                <label className={labelClass}>{t('backoffice.features')}</label>
+                <div className={checkboxesWrapClass}>
+                  {FEATURE_KEYS.map((feature) => (
+                    <label key={feature} className={checkboxClass}>
+                      <input type="checkbox" checked={companyEdit.featureKeys.includes(feature)} onChange={() => setCompanyEdit(prev => ({ ...prev, featureKeys: toggleInArray(prev.featureKeys, feature) }))} />
+                      {feature}
+                    </label>
+                  ))}
+                </div>
+              </div>
+              <button className={`${primaryButtonClass} mt-2`} type="submit">{t('backoffice.updateCompany')}</button>
+            </form>
+          ) : <p className="text-sm text-[var(--text-muted)]">{t('ui.loading')}</p>}
+        </>
       )}
+      {isUsersSection && canUpdateUsers && (
+        <>
+          <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.editUser')}</h3>
+          {userDetail ? (
+            <form onSubmit={onUpdateUser}>
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div>
+                  <label className={labelClass}>{t('auth.name')}</label>
+                  <input className={inputClass} value={userEdit.name} onChange={(e) => setUserEdit(prev => ({ ...prev, name: e.target.value }))} required />
+                </div>
+                <div>
+                  <label className={labelClass}>{t('auth.surname')}</label>
+                  <input className={inputClass} value={userEdit.surname} onChange={(e) => setUserEdit(prev => ({ ...prev, surname: e.target.value }))} required />
+                </div>
+                <div>
+                  <label className={labelClass}>{t('auth.email')}</label>
+                  <input className={inputClass} type="email" value={userEdit.email} onChange={(e) => setUserEdit(prev => ({ ...prev, email: e.target.value }))} required />
+                </div>
+                <div>
+                  <label className={labelClass}>{t('backoffice.language')}</label>
+                  <select className={inputClass} value={userEdit.language} onChange={(e) => setUserEdit(prev => ({ ...prev, language: e.target.value }))}>
+                    <option value="en">{t('ui.languageEnglish')}</option>
+                    <option value="es">{t('ui.languageSpanish')}</option>
+                    <option value="ca">{t('ui.languageCatalan')}</option>
+                  </select>
+                </div>
+                <div>
+                  <label className={labelClass}>{t('backoffice.role')}</label>
+                  <select className={inputClass} value={userEdit.role} onChange={(e) => {
+                    const role = e.target.value
+                    setUserEdit(prev => ({ ...prev, role, permissionKeys: permissionTemplateForRole(role) }))
+                  }}>
+                    <option value="staff">{t('roles.staff')}</option>
+                    <option value="owner">{t('roles.owner')}</option>
+                    <option value="admin">{t('roles.admin')}</option>
+                    <option value="dispatcher">{t('roles.dispatcher')}</option>
+                    <option value="viewer">{t('roles.viewer')}</option>
+                  </select>
+                </div>
+                <div>
+                  <label className={labelClass}>{t('backoffice.company')}</label>
+                  <select className={inputClass} value={userEdit.companyId} onChange={(e) => setUserEdit(prev => ({ ...prev, companyId: e.target.value }))}>
+                    <option value="">{t('backoffice.selectCompanyShort')}</option>
+                    {companyOptions.map((company) => (
+                      <option key={company.id} value={company.id}>{company.label}</option>
+                    ))}
+                  </select>
+                </div>
+                <div className="md:col-span-2">
+                  <label className={labelClass}>{t('backoffice.permissions')}</label>
+                  <div className={checkboxesWrapClass}>
+                    {PERMISSION_KEYS.map((permission) => (
+                      <label key={permission} className={checkboxClass}>
+                        <input type="checkbox" checked={userEdit.permissionKeys.includes(permission)} onChange={() => setUserEdit(prev => ({ ...prev, permissionKeys: toggleInArray(prev.permissionKeys, permission) }))} />
+                        {permission}
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              </div>
+              <button className={`${primaryButtonClass} mt-6`} type="submit">{t('backoffice.updateUser')}</button>
+            </form>
+          ) : <p className="text-sm text-[var(--text-muted)]">{t('ui.loading')}</p>}
+        </>
+      )}
+      {isTrackersSection && canUpdateTrackers && (
+        <>
+          <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.editTrackerAlias')}</h3>
+          {trackerDetail ? (
+            <form onSubmit={onUpdateTracker}>
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div>
+                  <label className={labelClass}>{t('trackers.serialNumber')}</label>
+                  <input className={inputClass} value={trackerDetail.serialNumber} readOnly />
+                </div>
+                <div>
+                  <label className={labelClass}>{t('ui.emoji')}</label>
+                  <select className={inputClass} value={trackerEmojiEdit} onChange={(e) => setTrackerEmojiEdit(e.target.value)}>
+                    {TRACKER_EMOJIS.map((option) => (
+                      <option key={option.value} value={option.value}>{option.value} {option.label}</option>
+                    ))}
+                  </select>
+                </div>
+                <div className="md:col-span-2">
+                  <label className={labelClass}>{t('ui.alias')}</label>
+                  <input className={inputClass} value={trackerAliasEdit} onChange={(e) => setTrackerAliasEdit(e.target.value)} required />
+                </div>
+              </div>
+              <button className={`${primaryButtonClass} mt-6`} type="submit">{t('backoffice.updateTrackerAlias')}</button>
+            </form>
+          ) : <p className="text-sm text-[var(--text-muted)]">{t('ui.loading')}</p>}
+        </>
+      )}
+    </section>
+  )
 
-      {isTrackersSection && isDetailView && canReadTrackers && trackerDetail && (
-      <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
-        <h3 className="mb-4 text-xl font-bold text-[var(--text-primary)]">{t('backoffice.editTrackerAlias')}</h3>
-        <form onSubmit={onUpdateTracker}>
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-            <div>
-              <label className={labelClass}>{t('trackers.serialNumber')}</label>
-              <input className={inputClass} value={trackerDetail.serialNumber} readOnly />
-            </div>
-            <div>
-              <label className={labelClass}>{t('ui.emoji')}</label>
-              <select
-                className={inputClass}
-                value={trackerEmojiEdit}
-                onChange={(e) => setTrackerEmojiEdit(e.target.value)}
-                disabled={!canUpdateTrackers}
-              >
-                {TRACKER_EMOJIS.map((option) => (
-                  <option key={option.value} value={option.value}>{option.value} {option.label}</option>
-                ))}
-              </select>
-            </div>
-            <div className="md:col-span-2">
-              <label className={labelClass}>{t('ui.alias')}</label>
-              <input
-                className={inputClass}
-                value={trackerAliasEdit}
-                onChange={(e) => setTrackerAliasEdit(e.target.value)}
-                required
-                readOnly={!canUpdateTrackers}
-              />
-            </div>
-          </div>
-          {canUpdateTrackers && (
-            <button className={`${primaryButtonClass} mt-6`} type="submit">{t('backoffice.updateTrackerAlias')}</button>
-          )}
-        </form>
-      </section>
-      )}
+  return (
+    <PageShell title={t('backoffice.title')}>
+      {loading && <p className="text-center text-[var(--text-muted)]">{t('backoffice.loading')}</p>}
+      {renderSectionTabs()}
+      {!isIndexView && renderBack()}
+      {isIndexView && renderIndexActions()}
+      <div className="space-y-8">
+        {isIndexView && renderIndex()}
+        {isCreateView && renderCreate()}
+        {isEditView && renderEdit()}
       </div>
     </PageShell>
   )

--- a/track-app/src/components/Backoffice/index.tsx
+++ b/track-app/src/components/Backoffice/index.tsx
@@ -11,6 +11,13 @@ function toggleInArray(list: string[], value: string): string[] {
   return list.includes(value) ? list.filter(item => item !== value) : [...list, value]
 }
 
+type ConfirmModalState = {
+  title: string
+  description: string
+  confirmLabel: string
+  onConfirm: () => Promise<void>
+}
+
 interface BackofficeProps {
   section: 'companies' | 'users' | 'trackers'
   mode: 'index' | 'create' | 'edit'
@@ -49,9 +56,9 @@ function Backoffice({
   const labelClass = 'mb-2 block text-sm font-semibold'
   const inputClass = 'glass-input-base w-full rounded-xl border px-3 py-2 text-sm outline-none transition'
   const primaryButtonClass = 'inline-flex items-center justify-center rounded-full border border-amber-500 bg-amber-400 px-4 py-2 text-sm font-semibold text-slate-800 transition hover:brightness-105'
-  const checkboxClass = 'inline-flex items-center gap-2 text-sm text-[var(--text-primary)]'
   const sectionClass = 'pb-8 border-b space-y-4'
-  const checkboxesWrapClass = 'flex flex-wrap gap-x-4 gap-y-2'
+  const switchGridClass = 'grid grid-cols-1 md:grid-cols-2 gap-2'
+  const permissionsGridClass = 'grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-2'
 
   const isCompaniesSection = section === 'companies'
   const isUsersSection = section === 'users'
@@ -84,7 +91,8 @@ function Backoffice({
     updateTracker,
     deleteCompany,
     deleteUser,
-    deleteTracker
+    deleteTracker,
+    setUserPermission
   } = useBackoffice(
     usersPage,
     20,
@@ -122,6 +130,9 @@ function Backoffice({
   })
   const [trackerAliasEdit, setTrackerAliasEdit] = useState('')
   const [trackerEmojiEdit, setTrackerEmojiEdit] = useState('🚚')
+  const [permissionSaving, setPermissionSaving] = useState(false)
+  const [confirmState, setConfirmState] = useState<ConfirmModalState | null>(null)
+  const [confirmLoading, setConfirmLoading] = useState(false)
 
   const companyOptions = useMemo(
     () => companies.map((company) => ({ id: company.id, label: `${company.name} (${company.slug})` })),
@@ -231,7 +242,47 @@ function Backoffice({
     await updateTracker(trackerDetail.id, { alias: trackerAliasEdit.trim(), emoji: trackerEmojiEdit })
   }
 
-  const askDelete = (label: string) => window.confirm(`${t('ui.delete')} "${label}"?`)
+  const onToggleEditPermission = async (permissionKey: string, enabled: boolean) => {
+    if (!userDetail?.id || permissionSaving) return
+    const previous = [...userEdit.permissionKeys]
+    const next = enabled
+      ? (previous.includes(permissionKey) ? previous : [...previous, permissionKey])
+      : previous.filter((item) => item !== permissionKey)
+    setUserEdit((prev) => ({ ...prev, permissionKeys: next }))
+    setPermissionSaving(true)
+    try {
+      await setUserPermission(userDetail.id, permissionKey, enabled)
+    } catch {
+      setUserEdit((prev) => ({ ...prev, permissionKeys: previous }))
+    } finally {
+      setPermissionSaving(false)
+    }
+  }
+
+  const openDeleteModal = (title: string, description: string, onConfirm: () => Promise<void>) => {
+    setConfirmState({
+      title,
+      description,
+      confirmLabel: t('ui.delete'),
+      onConfirm
+    })
+  }
+
+  const closeConfirmModal = () => {
+    if (confirmLoading) return
+    setConfirmState(null)
+  }
+
+  const submitConfirm = async () => {
+    if (!confirmState) return
+    setConfirmLoading(true)
+    try {
+      await confirmState.onConfirm()
+      setConfirmState(null)
+    } finally {
+      setConfirmLoading(false)
+    }
+  }
 
   const renderSectionTabs = () => (
     <div className="mb-6 flex flex-wrap gap-2">
@@ -275,6 +326,29 @@ function Backoffice({
     </div>
   )
 
+  const renderSwitch = (
+    label: string,
+    checked: boolean,
+    onChange: (next: boolean) => void,
+    disabled = false
+  ) => (
+    <label className={`inline-flex items-center justify-between gap-3 rounded-xl border px-3 py-2 text-sm ${disabled ? 'opacity-60' : ''}`}>
+      <span className="text-[var(--text-primary)]">{label}</span>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        disabled={disabled}
+        onClick={() => onChange(!checked)}
+        className={`relative inline-flex h-6 w-11 items-center rounded-full transition ${checked ? 'bg-amber-400' : 'bg-slate-400/50'} ${disabled ? 'cursor-not-allowed' : ''}`}
+      >
+        <span
+          className={`inline-block h-5 w-5 transform rounded-full bg-white transition ${checked ? 'translate-x-5' : 'translate-x-1'}`}
+        />
+      </button>
+    </label>
+  )
+
   const renderIndexActions = () => (
     <div className="mb-6 flex justify-end">
       {isCompaniesSection && canCreateCompanies && (
@@ -298,7 +372,13 @@ function Backoffice({
           emptyMessage={t('backoffice.noCompanies')}
           variant="flat"
           onEdit={canUpdateCompanies ? (company) => navigate(`/backoffice/companies/${company.id}`) : undefined}
-          onDelete={canUpdateCompanies ? async (company) => { if (askDelete(company.name)) await deleteCompany(company.id) } : undefined}
+          onDelete={canUpdateCompanies ? (company) => {
+            openDeleteModal(
+              t('backoffice.confirmDeleteTitle'),
+              t('backoffice.confirmDeleteMessage', { entity: company.name }),
+              () => deleteCompany(company.id)
+            )
+          } : undefined}
         />
       )}
       {isUsersSection && (
@@ -308,7 +388,13 @@ function Backoffice({
           emptyMessage={t('backoffice.noUsers')}
           variant="flat"
           onEdit={canUpdateUsers ? (user) => navigate(`/backoffice/users/${user.id}`) : undefined}
-          onDelete={canDeleteUsers ? async (user) => { if (askDelete(user.email)) await deleteUser(user.id) } : undefined}
+          onDelete={canDeleteUsers ? (user) => {
+            openDeleteModal(
+              t('backoffice.confirmDeleteTitle'),
+              t('backoffice.confirmDeleteMessage', { entity: user.email }),
+              () => deleteUser(user.id)
+            )
+          } : undefined}
           pageSize={20}
           serverPagination={{
             enabled: true,
@@ -325,7 +411,14 @@ function Backoffice({
           emptyMessage={t('trackers.empty')}
           variant="flat"
           onEdit={canUpdateTrackers ? (tracker) => navigate(`/backoffice/trackers/${tracker.id}`) : undefined}
-          onDelete={canDeleteTrackers ? async (tracker) => { if (askDelete(tracker.alias || tracker.serialNumber)) await deleteTracker(tracker.id) } : undefined}
+          onDelete={canDeleteTrackers ? (tracker) => {
+            const entity = tracker.alias || tracker.serialNumber
+            openDeleteModal(
+              t('backoffice.confirmDeleteTitle'),
+              t('backoffice.confirmDeleteMessage', { entity }),
+              () => deleteTracker(tracker.id)
+            )
+          } : undefined}
           pageSize={20}
           serverPagination={{
             enabled: true,
@@ -348,19 +441,23 @@ function Backoffice({
             <input className={inputClass} value={companyForm.name} onChange={(e) => setCompanyForm(prev => ({ ...prev, name: e.target.value }))} required />
           </div>
           <div className="mb-4">
-            <label className="inline-flex items-center gap-2 text-sm text-[var(--text-primary)]">
-              <input type="checkbox" checked={companyForm.active} onChange={(e) => setCompanyForm(prev => ({ ...prev, active: e.target.checked }))} />
-              {t('backoffice.active')}
-            </label>
+            {renderSwitch(
+              t('backoffice.active'),
+              companyForm.active,
+              (next) => setCompanyForm(prev => ({ ...prev, active: next }))
+            )}
           </div>
           <div className="mb-4">
             <label className={labelClass}>{t('backoffice.features')}</label>
-            <div className={checkboxesWrapClass}>
+            <div className={switchGridClass}>
               {FEATURE_KEYS.map((feature) => (
-                <label key={feature} className={checkboxClass}>
-                  <input type="checkbox" checked={companyForm.featureKeys.includes(feature)} onChange={() => setCompanyForm(prev => ({ ...prev, featureKeys: toggleInArray(prev.featureKeys, feature) }))} />
-                  {feature}
-                </label>
+                <React.Fragment key={feature}>
+                  {renderSwitch(
+                    feature,
+                    companyForm.featureKeys.includes(feature),
+                    () => setCompanyForm(prev => ({ ...prev, featureKeys: toggleInArray(prev.featureKeys, feature) }))
+                  )}
+                </React.Fragment>
               ))}
             </div>
           </div>
@@ -419,12 +516,15 @@ function Backoffice({
             </div>
             <div className="md:col-span-2">
               <label className={labelClass}>{t('backoffice.permissions')}</label>
-              <div className={checkboxesWrapClass}>
+              <div className={permissionsGridClass}>
                 {PERMISSION_KEYS.map((permission) => (
-                  <label key={permission} className={checkboxClass}>
-                    <input type="checkbox" checked={userForm.permissionKeys.includes(permission)} onChange={() => setUserForm(prev => ({ ...prev, permissionKeys: toggleInArray(prev.permissionKeys, permission) }))} />
-                    {permission}
-                  </label>
+                  <React.Fragment key={permission}>
+                    {renderSwitch(
+                      permission,
+                      userForm.permissionKeys.includes(permission),
+                      () => setUserForm(prev => ({ ...prev, permissionKeys: toggleInArray(prev.permissionKeys, permission) }))
+                    )}
+                  </React.Fragment>
                 ))}
               </div>
             </div>
@@ -484,19 +584,23 @@ function Backoffice({
                 <input className={inputClass} value={companyEdit.slug} readOnly />
               </div>
               <div className="mb-4">
-                <label className="inline-flex items-center gap-2 text-sm text-[var(--text-primary)]">
-                  <input type="checkbox" checked={companyEdit.active} onChange={(e) => setCompanyEdit(prev => ({ ...prev, active: e.target.checked }))} />
-                  {t('backoffice.active')}
-                </label>
+                {renderSwitch(
+                  t('backoffice.active'),
+                  companyEdit.active,
+                  (next) => setCompanyEdit(prev => ({ ...prev, active: next }))
+                )}
               </div>
               <div className="mb-4">
                 <label className={labelClass}>{t('backoffice.features')}</label>
-                <div className={checkboxesWrapClass}>
+                <div className={switchGridClass}>
                   {FEATURE_KEYS.map((feature) => (
-                    <label key={feature} className={checkboxClass}>
-                      <input type="checkbox" checked={companyEdit.featureKeys.includes(feature)} onChange={() => setCompanyEdit(prev => ({ ...prev, featureKeys: toggleInArray(prev.featureKeys, feature) }))} />
-                      {feature}
-                    </label>
+                    <React.Fragment key={feature}>
+                      {renderSwitch(
+                        feature,
+                        companyEdit.featureKeys.includes(feature),
+                        () => setCompanyEdit(prev => ({ ...prev, featureKeys: toggleInArray(prev.featureKeys, feature) }))
+                      )}
+                    </React.Fragment>
                   ))}
                 </div>
               </div>
@@ -555,14 +659,21 @@ function Backoffice({
                 </div>
                 <div className="md:col-span-2">
                   <label className={labelClass}>{t('backoffice.permissions')}</label>
-                  <div className={checkboxesWrapClass}>
+                  <div className={permissionsGridClass}>
                     {PERMISSION_KEYS.map((permission) => (
-                      <label key={permission} className={checkboxClass}>
-                        <input type="checkbox" checked={userEdit.permissionKeys.includes(permission)} onChange={() => setUserEdit(prev => ({ ...prev, permissionKeys: toggleInArray(prev.permissionKeys, permission) }))} />
-                        {permission}
-                      </label>
+                      <React.Fragment key={permission}>
+                        {renderSwitch(
+                          permission,
+                          userEdit.permissionKeys.includes(permission),
+                          (next) => onToggleEditPermission(permission, next),
+                          permissionSaving
+                        )}
+                      </React.Fragment>
                     ))}
                   </div>
+                  {permissionSaving && (
+                    <p className="mt-2 text-xs text-[var(--text-muted)]">{t('backoffice.savingPermissions')}</p>
+                  )}
                 </div>
               </div>
               <button className={`${primaryButtonClass} mt-6`} type="submit">{t('backoffice.updateUser')}</button>
@@ -612,6 +723,32 @@ function Backoffice({
         {isCreateView && renderCreate()}
         {isEditView && renderEdit()}
       </div>
+      {confirmState && (
+        <div className="fixed inset-0 z-[1400] flex items-center justify-center bg-black/45 p-4">
+          <div className="w-full max-w-md rounded-2xl border bg-[var(--bg-surface)] p-5 shadow-2xl">
+            <h4 className="text-lg font-bold text-[var(--text-primary)]">{confirmState.title}</h4>
+            <p className="mt-2 text-sm text-[var(--text-secondary)]">{confirmState.description}</p>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                className="rounded-full border px-4 py-2 text-sm font-semibold"
+                onClick={closeConfirmModal}
+                disabled={confirmLoading}
+              >
+                {t('ui.cancel')}
+              </button>
+              <button
+                type="button"
+                className="rounded-full border border-red-700 bg-red-700 px-4 py-2 text-sm font-semibold text-white"
+                onClick={submitConfirm}
+                disabled={confirmLoading}
+              >
+                {confirmLoading ? t('ui.loading') : confirmState.confirmLabel}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </PageShell>
   )
 }

--- a/track-app/src/graphql/backoffice.gql
+++ b/track-app/src/graphql/backoffice.gql
@@ -8,6 +8,16 @@ query BackofficeCompanies {
   }
 }
 
+query BackofficeCompany($id: ID!) {
+  backofficeCompany(id: $id) {
+    id
+    name
+    slug
+    active
+    featureKeys
+  }
+}
+
 query BackofficeUsers($companyId: ID, $offset: Int = 0, $limit: Int = 20) {
   backofficeUsers(companyId: $companyId, offset: $offset, limit: $limit) {
     totalCount
@@ -21,6 +31,19 @@ query BackofficeUsers($companyId: ID, $offset: Int = 0, $limit: Int = 20) {
       companyId
       permissionKeys
     }
+  }
+}
+
+query BackofficeUser($id: ID!) {
+  backofficeUser(id: $id) {
+    id
+    name
+    surname
+    email
+    language
+    role
+    companyId
+    permissionKeys
   }
 }
 
@@ -85,6 +108,27 @@ mutation BackofficeUpdateTrackerAlias($id: ID!, $alias: String!) {
 
 mutation BackofficeUpdateUser($id: ID!, $input: BackofficeUpdateUserInput!) {
   backofficeUpdateUser(id: $id, input: $input) {
+    success
+    message
+  }
+}
+
+mutation BackofficeDeleteCompany($id: ID!) {
+  backofficeDeleteCompany(id: $id) {
+    success
+    message
+  }
+}
+
+mutation BackofficeDeleteUser($id: ID!) {
+  backofficeDeleteUser(id: $id) {
+    success
+    message
+  }
+}
+
+mutation BackofficeDeleteTracker($id: ID!) {
+  backofficeDeleteTracker(id: $id) {
     success
     message
   }

--- a/track-app/src/graphql/backoffice.gql
+++ b/track-app/src/graphql/backoffice.gql
@@ -133,3 +133,10 @@ mutation BackofficeDeleteTracker($id: ID!) {
     message
   }
 }
+
+mutation BackofficeSetUserPermission($id: ID!, $permissionKey: String!, $enabled: Boolean!) {
+  backofficeSetUserPermission(id: $id, permissionKey: $permissionKey, enabled: $enabled) {
+    success
+    message
+  }
+}

--- a/track-app/src/hooks/useBackoffice.ts
+++ b/track-app/src/hooks/useBackoffice.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { gql, useMutation } from '@apollo/client'
+import { gql, useMutation, useQuery } from '@apollo/client'
 import { toast } from 'react-toastify'
 import {
     BackofficeTrackerDocument,
@@ -21,6 +21,60 @@ import {
 const BACKOFFICE_UPDATE_TRACKER_MUTATION = gql`
     mutation BackofficeUpdateTracker($id: ID!, $input: BackofficeUpdateTrackerInput!) {
         backofficeUpdateTracker(id: $id, input: $input) {
+            success
+            message
+        }
+    }
+`
+
+const BACKOFFICE_COMPANY_QUERY = gql`
+    query BackofficeCompany($id: ID!) {
+        backofficeCompany(id: $id) {
+            id
+            name
+            slug
+            active
+            featureKeys
+        }
+    }
+`
+
+const BACKOFFICE_USER_QUERY = gql`
+    query BackofficeUser($id: ID!) {
+        backofficeUser(id: $id) {
+            id
+            name
+            surname
+            email
+            language
+            role
+            companyId
+            permissionKeys
+        }
+    }
+`
+
+const BACKOFFICE_DELETE_COMPANY_MUTATION = gql`
+    mutation BackofficeDeleteCompany($id: ID!) {
+        backofficeDeleteCompany(id: $id) {
+            success
+            message
+        }
+    }
+`
+
+const BACKOFFICE_DELETE_USER_MUTATION = gql`
+    mutation BackofficeDeleteUser($id: ID!) {
+        backofficeDeleteUser(id: $id) {
+            success
+            message
+        }
+    }
+`
+
+const BACKOFFICE_DELETE_TRACKER_MUTATION = gql`
+    mutation BackofficeDeleteTracker($id: ID!) {
+        backofficeDeleteTracker(id: $id) {
             success
             message
         }
@@ -60,7 +114,9 @@ export function useBackoffice(
     trackersPage = 1,
     trackersPageSize = 20,
     enableTrackersQuery = false,
-    trackerId?: string
+    trackerId?: string,
+    companyId?: string,
+    userId?: string
 ) {
     const offset = Math.max(0, (usersPage - 1) * pageSize)
     const trackersOffset = Math.max(0, (trackersPage - 1) * trackersPageSize)
@@ -88,6 +144,20 @@ export function useBackoffice(
         errorPolicy: 'all',
         skip: !trackerId,
         variables: { id: trackerId || '' },
+        onError: (err) => toast.error(err.message)
+    })
+    const companyDetailQuery = useQuery(BACKOFFICE_COMPANY_QUERY, {
+        fetchPolicy: 'cache-and-network',
+        errorPolicy: 'all',
+        skip: !companyId,
+        variables: { id: companyId || '' },
+        onError: (err) => toast.error(err.message)
+    })
+    const userDetailQuery = useQuery(BACKOFFICE_USER_QUERY, {
+        fetchPolicy: 'cache-and-network',
+        errorPolicy: 'all',
+        skip: !userId,
+        variables: { id: userId || '' },
         onError: (err) => toast.error(err.message)
     })
 
@@ -119,6 +189,15 @@ export function useBackoffice(
         onError: (err) => toast.error(err.message)
     })
     const [updateTrackerMutation] = useMutation(BACKOFFICE_UPDATE_TRACKER_MUTATION, {
+        onError: (err) => toast.error(err.message)
+    })
+    const [deleteCompanyMutation] = useMutation(BACKOFFICE_DELETE_COMPANY_MUTATION, {
+        onError: (err) => toast.error(err.message)
+    })
+    const [deleteUserMutation] = useMutation(BACKOFFICE_DELETE_USER_MUTATION, {
+        onError: (err) => toast.error(err.message)
+    })
+    const [deleteTrackerMutation] = useMutation(BACKOFFICE_DELETE_TRACKER_MUTATION, {
         onError: (err) => toast.error(err.message)
     })
 
@@ -165,6 +244,31 @@ export function useBackoffice(
             emoji: t.emoji ?? '🚚'
         }
     }, [trackerDetailQuery.data])
+    const companyDetail = useMemo<BackofficeCompany | null>(() => {
+        const c = companyDetailQuery.data?.backofficeCompany
+        if (!c) return null
+        return {
+            id: c.id,
+            name: c.name,
+            slug: c.slug,
+            active: c.active,
+            featureKeys: c.featureKeys ?? []
+        }
+    }, [companyDetailQuery.data])
+    const userDetail = useMemo<BackofficeUser | null>(() => {
+        const u = userDetailQuery.data?.backofficeUser
+        if (!u) return null
+        return {
+            id: u.id,
+            name: u.name,
+            surname: u.surname,
+            email: u.email,
+            language: u.language || 'en',
+            role: u.role,
+            companyId: u.companyId ?? null,
+            permissionKeys: u.permissionKeys ?? []
+        }
+    }, [userDetailQuery.data])
 
     const createCompany = async (name: string, active: boolean, featureKeys?: string[]) => {
         const res = await createCompanyMutation({ variables: { input: { name, active, featureKeys } } })
@@ -232,11 +336,34 @@ export function useBackoffice(
         })
         if (res.data?.backofficeUpdateTracker?.success) toast.success(res.data.backofficeUpdateTracker.message)
     }
+    const deleteCompany = async (id: string) => {
+        const res = await deleteCompanyMutation({
+            variables: { id },
+            refetchQueries: [{ query: BackofficeCompaniesDocument }]
+        })
+        if (res.data?.backofficeDeleteCompany?.success) toast.success(res.data.backofficeDeleteCompany.message)
+    }
+    const deleteUser = async (id: string) => {
+        const res = await deleteUserMutation({
+            variables: { id },
+            refetchQueries: [{ query: BackofficeUsersDocument }]
+        })
+        if (res.data?.backofficeDeleteUser?.success) toast.success(res.data.backofficeDeleteUser.message)
+    }
+    const deleteTracker = async (id: string) => {
+        const res = await deleteTrackerMutation({
+            variables: { id },
+            refetchQueries: [{ query: BackofficeTrackersDocument }]
+        })
+        if (res.data?.backofficeDeleteTracker?.success) toast.success(res.data.backofficeDeleteTracker.message)
+    }
 
     return {
         companies,
         users,
         trackers,
+        companyDetail,
+        userDetail,
         trackerDetail,
         usersTotalCount: enableUsersQuery ? (usersQuery.data?.backofficeUsers?.totalCount ?? 0) : 0,
         trackersTotalCount: enableTrackersQuery ? (trackersQuery.data?.backofficeTrackers?.totalCount ?? 0) : 0,
@@ -247,6 +374,9 @@ export function useBackoffice(
         createTracker,
         updateUser,
         updateTrackerAlias,
-        updateTracker
+        updateTracker,
+        deleteCompany,
+        deleteUser,
+        deleteTracker
     }
 }

--- a/track-app/src/hooks/useBackoffice.ts
+++ b/track-app/src/hooks/useBackoffice.ts
@@ -81,6 +81,15 @@ const BACKOFFICE_DELETE_TRACKER_MUTATION = gql`
     }
 `
 
+const BACKOFFICE_SET_USER_PERMISSION_MUTATION = gql`
+    mutation BackofficeSetUserPermission($id: ID!, $permissionKey: String!, $enabled: Boolean!) {
+        backofficeSetUserPermission(id: $id, permissionKey: $permissionKey, enabled: $enabled) {
+            success
+            message
+        }
+    }
+`
+
 export type BackofficeCompany = {
     id: string
     name: string
@@ -198,6 +207,9 @@ export function useBackoffice(
         onError: (err) => toast.error(err.message)
     })
     const [deleteTrackerMutation] = useMutation(BACKOFFICE_DELETE_TRACKER_MUTATION, {
+        onError: (err) => toast.error(err.message)
+    })
+    const [setUserPermissionMutation] = useMutation(BACKOFFICE_SET_USER_PERMISSION_MUTATION, {
         onError: (err) => toast.error(err.message)
     })
 
@@ -357,6 +369,13 @@ export function useBackoffice(
         })
         if (res.data?.backofficeDeleteTracker?.success) toast.success(res.data.backofficeDeleteTracker.message)
     }
+    const setUserPermission = async (id: string, permissionKey: string, enabled: boolean) => {
+        const res = await setUserPermissionMutation({
+            variables: { id, permissionKey, enabled },
+            refetchQueries: [{ query: BackofficeUsersDocument }]
+        })
+        if (res.data?.backofficeSetUserPermission?.success) toast.success(res.data.backofficeSetUserPermission.message)
+    }
 
     return {
         companies,
@@ -377,6 +396,7 @@ export function useBackoffice(
         updateTracker,
         deleteCompany,
         deleteUser,
-        deleteTracker
+        deleteTracker,
+        setUserPermission
     }
 }

--- a/track-app/src/locales/ca/common.json
+++ b/track-app/src/locales/ca/common.json
@@ -183,7 +183,10 @@
     "noUsers": "Encara no hi ha usuaris.",
     "updateCompany": "Actualitzar companyia",
     "updateUser": "Actualitzar usuari",
-    "updateTrackerAlias": "Actualitzar tracker"
+    "updateTrackerAlias": "Actualitzar tracker",
+    "confirmDeleteTitle": "Confirmar eliminació",
+    "confirmDeleteMessage": "Segur que vols eliminar \"{{entity}}\"?",
+    "savingPermissions": "Desant permisos..."
   },
   "app": {
     "brandName": "TorToise GPS",

--- a/track-app/src/locales/en/common.json
+++ b/track-app/src/locales/en/common.json
@@ -183,7 +183,10 @@
     "noUsers": "No users yet.",
     "updateCompany": "Update Company",
     "updateUser": "Update User",
-    "updateTrackerAlias": "Update Tracker"
+    "updateTrackerAlias": "Update Tracker",
+    "confirmDeleteTitle": "Confirm Delete",
+    "confirmDeleteMessage": "Are you sure you want to delete \"{{entity}}\"?",
+    "savingPermissions": "Saving permissions..."
   },
   "app": {
     "brandName": "TorToise GPS",

--- a/track-app/src/locales/es/common.json
+++ b/track-app/src/locales/es/common.json
@@ -183,7 +183,10 @@
     "noUsers": "Aún no hay usuarios.",
     "updateCompany": "Actualizar compañía",
     "updateUser": "Actualizar usuario",
-    "updateTrackerAlias": "Actualizar tracker"
+    "updateTrackerAlias": "Actualizar tracker",
+    "confirmDeleteTitle": "Confirmar eliminación",
+    "confirmDeleteMessage": "¿Seguro que quieres eliminar \"{{entity}}\"?",
+    "savingPermissions": "Guardando permisos..."
   },
   "app": {
     "brandName": "TorToise GPS",


### PR DESCRIPTION
## Resumen

- Separa Backoffice en vistas independientes de `index`, `create` y `edit` para `companies`, `users` y `trackers`.
- El índice muestra solo tabla y acciones.
- La creación y edición viven en rutas separadas para reducir confusión visual.

## Cambios UI

- Añade botón de creación en cada índice (`/new`).
- Añade acciones de tabla: `Editar` y `Eliminar`.
- Reemplaza checkboxes por switches en formularios de Backoffice.
- Organiza permisos en grid por filas/columnas para mejorar legibilidad.
- Añade modal de confirmación visual para borrado:
  - `company`: icono y acento ámbar.
  - `user`: icono y acento azul.
  - `tracker`: icono y acento rojo.

## Cambios Backend

- Añade mutaciones de borrado en Backoffice:
  - `backofficeDeleteCompany`
  - `backofficeDeleteUser`
  - `backofficeDeleteTracker`
- Añade mutación para actualización inmediata de permisos:
  - `backofficeSetUserPermission(id, permissionKey, enabled)`
- Añade queries de detalle para edición desacoplada:
  - `backofficeCompany(id)`
  - `backofficeUser(id)`

## Flujo de permisos (live update)

- En edición de usuario, cada toggle de permiso dispara request inmediata al backend.
- Se persiste `permissionKey + enabled` al cambiar el switch.
- Si falla la request, la UI revierte el cambio optimista.

## Validación

- `npm run test:api`
- `npm run build -w track-app`

