### PR TITLE
Backoffice: filtros por company y búsqueda en tablas

### DIFF
--- a/track-api/src/backoffice/backoffice.repository.js
+++ b/track-api/src/backoffice/backoffice.repository.js
@@ -1,6 +1,44 @@
 const { models: { Company, User, Tracker, POI }, mongoose } = require('track-data')
 
 module.exports = {
+    _buildSearchRegex(search) {
+        const value = String(search || '').trim()
+        if (!value) return null
+        const escaped = value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+        return new RegExp(escaped, 'i')
+    },
+
+    _buildUserQuery({ companyId = null, search = '' } = {}) {
+        const query = {}
+        if (companyId) query.companyId = companyId
+
+        const searchRegex = this._buildSearchRegex(search)
+        if (searchRegex) {
+            query.$or = [
+                { name: searchRegex },
+                { surname: searchRegex },
+                { email: searchRegex },
+                { role: searchRegex },
+                { language: searchRegex }
+            ]
+        }
+        return query
+    },
+
+    _buildTrackerQuery({ companyId = null, search = '' } = {}) {
+        const query = {}
+        if (companyId) query.companyId = companyId
+
+        const searchRegex = this._buildSearchRegex(search)
+        if (searchRegex) {
+            query.$or = [
+                { serialNumber: searchRegex },
+                { alias: searchRegex }
+            ]
+        }
+        return query
+    },
+
     async findUserById(id) {
         return User.findById(id)
     },
@@ -31,15 +69,15 @@ module.exports = {
         return Company.findByIdAndUpdate(id, { $set: patch }, { new: true })
     },
 
-    async listUsers(companyId, { offset = 0, limit } = {}) {
-        const query = companyId ? { companyId } : {}
+    async listUsers(filters = {}, { offset = 0, limit } = {}) {
+        const query = this._buildUserQuery(filters)
         const result = User.find(query).sort({ createdAt: -1 }).skip(offset)
         if (typeof limit === 'number') result.limit(limit)
         return result.lean()
     },
 
-    async countUsers(companyId) {
-        const query = companyId ? { companyId } : {}
+    async countUsers(filters = {}) {
+        const query = this._buildUserQuery(filters)
         return User.countDocuments(query)
     },
 
@@ -69,15 +107,15 @@ module.exports = {
         return Tracker.findById(id)
     },
 
-    async listTrackers(companyId, { offset = 0, limit } = {}) {
-        const query = companyId ? { companyId } : {}
+    async listTrackers(filters = {}, { offset = 0, limit } = {}) {
+        const query = this._buildTrackerQuery(filters)
         const result = Tracker.find(query).sort({ createdAt: -1 }).skip(offset)
         if (typeof limit === 'number') result.limit(limit)
         return result.lean()
     },
 
-    async countTrackers(companyId) {
-        const query = companyId ? { companyId } : {}
+    async countTrackers(filters = {}) {
+        const query = this._buildTrackerQuery(filters)
         return Tracker.countDocuments(query)
     },
 

--- a/track-api/src/backoffice/backoffice.service.js
+++ b/track-api/src/backoffice/backoffice.service.js
@@ -123,26 +123,27 @@ const backofficeService = {
         return repo.updateCompanyById(companyId, patch)
     },
 
-    async listUsers(requesterId, companyId = null, pagination) {
+    async listUsers(requesterId, companyId = null, search = '', pagination) {
         await requireAccess(requesterId, { feature: 'backoffice', permission: 'users.read' })
         if (companyId) {
             validate.arguments([{ name: 'companyId', value: companyId, type: String, notEmpty: true }])
             const company = await repo.findCompanyById(companyId)
             if (!company) throw new LogicError(`company with id ${companyId} doesn't exists`)
         }
-        if (!pagination) return repo.listUsers(companyId)
+        const filters = { companyId, search }
+        if (!pagination) return repo.listUsers(filters)
         const _pagination = this.normalizePagination(pagination.offset, pagination.limit)
-        return repo.listUsers(companyId, _pagination)
+        return repo.listUsers(filters, _pagination)
     },
 
-    async countUsers(requesterId, companyId = null) {
+    async countUsers(requesterId, companyId = null, search = '') {
         await requireAccess(requesterId, { feature: 'backoffice', permission: 'users.read' })
         if (companyId) {
             validate.arguments([{ name: 'companyId', value: companyId, type: String, notEmpty: true }])
             const company = await repo.findCompanyById(companyId)
             if (!company) throw new LogicError(`company with id ${companyId} doesn't exists`)
         }
-        return repo.countUsers(companyId)
+        return repo.countUsers({ companyId, search })
     },
 
     async retrieveUser(requesterId, userId) {
@@ -153,26 +154,27 @@ const backofficeService = {
         return user
     },
 
-    async listTrackers(requesterId, companyId = null, pagination) {
+    async listTrackers(requesterId, companyId = null, search = '', pagination) {
         await requireAccess(requesterId, { feature: 'backoffice', permission: 'companies.read' })
         if (companyId) {
             validate.arguments([{ name: 'companyId', value: companyId, type: String, notEmpty: true }])
             const company = await repo.findCompanyById(companyId)
             if (!company) throw new LogicError(`company with id ${companyId} doesn't exists`)
         }
-        if (!pagination) return repo.listTrackers(companyId)
+        const filters = { companyId, search }
+        if (!pagination) return repo.listTrackers(filters)
         const _pagination = this.normalizePagination(pagination.offset, pagination.limit)
-        return repo.listTrackers(companyId, _pagination)
+        return repo.listTrackers(filters, _pagination)
     },
 
-    async countTrackers(requesterId, companyId = null) {
+    async countTrackers(requesterId, companyId = null, search = '') {
         await requireAccess(requesterId, { feature: 'backoffice', permission: 'companies.read' })
         if (companyId) {
             validate.arguments([{ name: 'companyId', value: companyId, type: String, notEmpty: true }])
             const company = await repo.findCompanyById(companyId)
             if (!company) throw new LogicError(`company with id ${companyId} doesn't exists`)
         }
-        return repo.countTrackers(companyId)
+        return repo.countTrackers({ companyId, search })
     },
 
     async retrieveTracker(requesterId, trackerId) {

--- a/track-api/src/graphql/resolvers/backoffice.resolver.js
+++ b/track-api/src/graphql/resolvers/backoffice.resolver.js
@@ -82,18 +82,23 @@ const backofficeResolver = {
 
     /**
      * @param {unknown} _
-     * @param {{ companyId?: string|null, offset?: number, limit?: number }} args
+     * @param {{ companyId?: string|null, search?: string|null, offset?: number, limit?: number }} args
      * @param {{ userId: string|null }} ctx
      */
-    async backofficeUsers(_, { companyId, offset, limit }, ctx) {
+    async backofficeUsers(_, { companyId, search, offset, limit }, ctx) {
       const userId = requireAuth(ctx)
       try {
         const result = await service.listUsers(
           userId,
           /** @type {any} */ (companyId),
+          /** @type {any} */ (search),
           { offset, limit }
         )
-        const totalCount = await service.countUsers(userId, /** @type {any} */ (companyId))
+        const totalCount = await service.countUsers(
+          userId,
+          /** @type {any} */ (companyId),
+          /** @type {any} */ (search)
+        )
         const rows = /** @type {any[]} */ (Array.isArray(result) ? result : [])
         return {
           items: rows.map(mapUser),
@@ -121,15 +126,15 @@ const backofficeResolver = {
 
     /**
      * @param {unknown} _
-     * @param {{ companyId?: string|null, offset?: number, limit?: number }} args
+     * @param {{ companyId?: string|null, search?: string|null, offset?: number, limit?: number }} args
      * @param {{ userId: string|null }} ctx
      */
-    async backofficeTrackers(_, { companyId, offset, limit }, ctx) {
+    async backofficeTrackers(_, { companyId, search, offset, limit }, ctx) {
       const userId = requireAuth(ctx)
       try {
         const [result, totalCount] = await Promise.all([
-          service.listTrackers(userId, /** @type {any} */ (companyId), { offset, limit }),
-          service.countTrackers(userId, /** @type {any} */ (companyId))
+          service.listTrackers(userId, /** @type {any} */ (companyId), /** @type {any} */ (search), { offset, limit }),
+          service.countTrackers(userId, /** @type {any} */ (companyId), /** @type {any} */ (search))
         ])
         const rows = /** @type {any[]} */ (Array.isArray(result) ? result : [])
         return {

--- a/track-api/src/graphql/schema.graphql
+++ b/track-api/src/graphql/schema.graphql
@@ -198,12 +198,14 @@ type Query {
   backofficeCompany(id: ID!): Company!
   backofficeUsers(
     companyId: ID
+    search: String
     offset: Int = 0
     limit: Int = 20
   ): PagedBackofficeUsers!
   backofficeUser(id: ID!): BackofficeUser!
   backofficeTrackers(
     companyId: ID
+    search: String
     offset: Int = 0
     limit: Int = 20
   ): PagedTrackers!

--- a/track-app/src/components/Backoffice/index.tsx
+++ b/track-app/src/components/Backoffice/index.tsx
@@ -74,6 +74,13 @@ function Backoffice({
 
   const [usersPage, setUsersPage] = useState(1)
   const [trackersPage, setTrackersPage] = useState(1)
+  const [companiesSearch, setCompaniesSearch] = useState('')
+  const [usersCompanyFilter, setUsersCompanyFilter] = useState('')
+  const [trackersCompanyFilter, setTrackersCompanyFilter] = useState('')
+  const [usersSearchInput, setUsersSearchInput] = useState('')
+  const [trackersSearchInput, setTrackersSearchInput] = useState('')
+  const [usersSearch, setUsersSearch] = useState('')
+  const [trackersSearch, setTrackersSearch] = useState('')
   const {
     companies,
     users,
@@ -98,9 +105,13 @@ function Backoffice({
     usersPage,
     20,
     shouldLoadUsers,
+    usersCompanyFilter || undefined,
+    usersSearch,
     trackersPage,
     20,
     shouldLoadTrackers,
+    trackersCompanyFilter || undefined,
+    trackersSearch,
     isTrackersSection && isEditView ? entityId : undefined,
     isCompaniesSection && isEditView ? entityId : undefined,
     isUsersSection && isEditView ? entityId : undefined
@@ -139,6 +150,35 @@ function Backoffice({
     () => companies.map((company) => ({ id: company.id, label: `${company.name} (${company.slug})` })),
     [companies]
   )
+  const companyLabelById = useMemo(
+    () => new Map(companyOptions.map((company) => [company.id, company.label])),
+    [companyOptions]
+  )
+  const normalizedCompaniesSearch = companiesSearch.trim().toLowerCase()
+  const filteredCompanies = useMemo(() => {
+    if (!normalizedCompaniesSearch) return companies
+    return companies.filter((company) =>
+      `${company.name} ${company.slug}`.toLowerCase().includes(normalizedCompaniesSearch)
+    )
+  }, [companies, normalizedCompaniesSearch])
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setUsersSearch(usersSearchInput.trim()), 300)
+    return () => window.clearTimeout(timer)
+  }, [usersSearchInput])
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setTrackersSearch(trackersSearchInput.trim()), 300)
+    return () => window.clearTimeout(timer)
+  }, [trackersSearchInput])
+
+  useEffect(() => {
+    setUsersPage(1)
+  }, [usersCompanyFilter, usersSearch])
+
+  useEffect(() => {
+    setTrackersPage(1)
+  }, [trackersCompanyFilter, trackersSearch])
 
   useEffect(() => {
     if (!companyDetail) return
@@ -181,7 +221,11 @@ function Backoffice({
     { key: 'email', label: t('auth.email') },
     { key: 'language', label: t('backoffice.language') },
     { key: 'role', label: t('backoffice.role') },
-    { key: 'companyId', label: t('backoffice.companyId') }
+    {
+      key: 'companyId',
+      label: t('backoffice.company'),
+      render: (row) => row.companyId ? (companyLabelById.get(row.companyId) || row.companyId) : '-'
+    }
   ]
   const TRACKER_COLUMNS: Column<BackofficeTracker>[] = [
     { key: 'emoji', label: t('ui.emoji'), render: (row) => row.emoji || '🚚' },
@@ -370,12 +414,52 @@ function Backoffice({
     </div>
   )
 
+  const renderIndexFilters = () => (
+    <div className="mb-4 grid grid-cols-1 gap-3 md:grid-cols-2">
+      <div>
+        <label className={labelClass}>{t('ui.search')}</label>
+        <input
+          className={inputClass}
+          type="search"
+          value={isCompaniesSection ? companiesSearch : isUsersSection ? usersSearchInput : trackersSearchInput}
+          onChange={(e) => {
+            const value = e.target.value
+            if (isCompaniesSection) setCompaniesSearch(value)
+            else if (isUsersSection) setUsersSearchInput(value)
+            else setTrackersSearchInput(value)
+          }}
+          placeholder={t('backoffice.searchPlaceholder')}
+        />
+      </div>
+      {(isUsersSection || isTrackersSection) && (
+        <div>
+          <label className={labelClass}>{t('backoffice.company')}</label>
+          <select
+            className={inputClass}
+            value={isUsersSection ? usersCompanyFilter : trackersCompanyFilter}
+            onChange={(e) => {
+              const value = e.target.value
+              if (isUsersSection) setUsersCompanyFilter(value)
+              else setTrackersCompanyFilter(value)
+            }}
+          >
+            <option value="">{t('backoffice.allCompanies')}</option>
+            {companyOptions.map((company) => (
+              <option key={company.id} value={company.id}>{company.label}</option>
+            ))}
+          </select>
+        </div>
+      )}
+    </div>
+  )
+
   const renderIndex = () => (
     <section className={sectionClass} style={{ borderColor: 'color-mix(in srgb, var(--border-default) 75%, transparent)' }}>
+      {renderIndexFilters()}
       {isCompaniesSection && (
         <DataTable
           columns={COMPANY_COLUMNS}
-          rows={companies}
+          rows={filteredCompanies}
           emptyMessage={t('backoffice.noCompanies')}
           variant="flat"
           onEdit={canUpdateCompanies ? (company) => navigate(`/backoffice/companies/${company.id}`) : undefined}

--- a/track-app/src/generated/graphql.ts
+++ b/track-app/src/generated/graphql.ts
@@ -74,6 +74,11 @@ export type BackofficeUpdateCompanyInput = {
   slug?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type BackofficeUpdateTrackerInput = {
+  alias?: InputMaybe<Scalars['String']['input']>;
+  emoji?: InputMaybe<Scalars['String']['input']>;
+};
+
 export type BackofficeUpdateUserInput = {
   companyId?: InputMaybe<Scalars['ID']['input']>;
   email?: InputMaybe<Scalars['String']['input']>;
@@ -123,7 +128,12 @@ export type Mutation = {
   backofficeCreateCompany: MutationResult;
   backofficeCreateTracker: MutationResult;
   backofficeCreateUser: MutationResult;
+  backofficeDeleteCompany: MutationResult;
+  backofficeDeleteTracker: MutationResult;
+  backofficeDeleteUser: MutationResult;
+  backofficeSetUserPermission: MutationResult;
   backofficeUpdateCompany: MutationResult;
+  backofficeUpdateTracker: MutationResult;
   backofficeUpdateTrackerAlias: MutationResult;
   backofficeUpdateUser: MutationResult;
   deletePOI: MutationResult;
@@ -162,9 +172,37 @@ export type MutationBackofficeCreateUserArgs = {
 };
 
 
+export type MutationBackofficeDeleteCompanyArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationBackofficeDeleteTrackerArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationBackofficeDeleteUserArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationBackofficeSetUserPermissionArgs = {
+  enabled: Scalars['Boolean']['input'];
+  id: Scalars['ID']['input'];
+  permissionKey: Scalars['String']['input'];
+};
+
+
 export type MutationBackofficeUpdateCompanyArgs = {
   id: Scalars['ID']['input'];
   input: BackofficeUpdateCompanyInput;
+};
+
+
+export type MutationBackofficeUpdateTrackerArgs = {
+  id: Scalars['ID']['input'];
+  input: BackofficeUpdateTrackerInput;
 };
 
 
@@ -254,8 +292,10 @@ export type PagedTrackers = {
 export type Query = {
   __typename?: 'Query';
   backofficeCompanies: Array<Company>;
+  backofficeCompany: Company;
   backofficeTracker: Tracker;
   backofficeTrackers: PagedTrackers;
+  backofficeUser: BackofficeUser;
   backofficeUsers: PagedBackofficeUsers;
   lastTrack?: Maybe<Track>;
   lastTracks: Array<LiveTrack>;
@@ -270,6 +310,11 @@ export type Query = {
 };
 
 
+export type QueryBackofficeCompanyArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
 export type QueryBackofficeTrackerArgs = {
   id: Scalars['ID']['input'];
 };
@@ -279,6 +324,12 @@ export type QueryBackofficeTrackersArgs = {
   companyId?: InputMaybe<Scalars['ID']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBackofficeUserArgs = {
+  id: Scalars['ID']['input'];
 };
 
 
@@ -286,6 +337,7 @@ export type QueryBackofficeUsersArgs = {
   companyId?: InputMaybe<Scalars['ID']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -405,14 +457,29 @@ export type BackofficeCompaniesQueryVariables = Exact<{ [key: string]: never; }>
 
 export type BackofficeCompaniesQuery = { __typename?: 'Query', backofficeCompanies: Array<{ __typename?: 'Company', id: string, name: string, slug: string, active: boolean, featureKeys: Array<string> }> };
 
+export type BackofficeCompanyQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type BackofficeCompanyQuery = { __typename?: 'Query', backofficeCompany: { __typename?: 'Company', id: string, name: string, slug: string, active: boolean, featureKeys: Array<string> } };
+
 export type BackofficeUsersQueryVariables = Exact<{
   companyId?: InputMaybe<Scalars['ID']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 
 export type BackofficeUsersQuery = { __typename?: 'Query', backofficeUsers: { __typename?: 'PagedBackofficeUsers', totalCount: number, items: Array<{ __typename?: 'BackofficeUser', id: string, name: string, surname: string, email: string, language: string, role: string, companyId?: string | null, permissionKeys: Array<string> }> } };
+
+export type BackofficeUserQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type BackofficeUserQuery = { __typename?: 'Query', backofficeUser: { __typename?: 'BackofficeUser', id: string, name: string, surname: string, email: string, language: string, role: string, companyId?: string | null, permissionKeys: Array<string> } };
 
 export type BackofficeCreateCompanyMutationVariables = Exact<{
   input: BackofficeCreateCompanyInput;
@@ -445,6 +512,7 @@ export type BackofficeCreateTrackerMutation = { __typename?: 'Mutation', backoff
 
 export type BackofficeTrackersQueryVariables = Exact<{
   companyId?: InputMaybe<Scalars['ID']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
 }>;
@@ -474,6 +542,36 @@ export type BackofficeUpdateUserMutationVariables = Exact<{
 
 
 export type BackofficeUpdateUserMutation = { __typename?: 'Mutation', backofficeUpdateUser: { __typename?: 'MutationResult', success: boolean, message: string } };
+
+export type BackofficeDeleteCompanyMutationVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type BackofficeDeleteCompanyMutation = { __typename?: 'Mutation', backofficeDeleteCompany: { __typename?: 'MutationResult', success: boolean, message: string } };
+
+export type BackofficeDeleteUserMutationVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type BackofficeDeleteUserMutation = { __typename?: 'Mutation', backofficeDeleteUser: { __typename?: 'MutationResult', success: boolean, message: string } };
+
+export type BackofficeDeleteTrackerMutationVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type BackofficeDeleteTrackerMutation = { __typename?: 'Mutation', backofficeDeleteTracker: { __typename?: 'MutationResult', success: boolean, message: string } };
+
+export type BackofficeSetUserPermissionMutationVariables = Exact<{
+  id: Scalars['ID']['input'];
+  permissionKey: Scalars['String']['input'];
+  enabled: Scalars['Boolean']['input'];
+}>;
+
+
+export type BackofficeSetUserPermissionMutation = { __typename?: 'Mutation', backofficeSetUserPermission: { __typename?: 'MutationResult', success: boolean, message: string } };
 
 export type GetTrackersQueryVariables = Exact<{
   offset?: InputMaybe<Scalars['Int']['input']>;
@@ -654,9 +752,61 @@ export type BackofficeCompaniesQueryHookResult = ReturnType<typeof useBackoffice
 export type BackofficeCompaniesLazyQueryHookResult = ReturnType<typeof useBackofficeCompaniesLazyQuery>;
 export type BackofficeCompaniesSuspenseQueryHookResult = ReturnType<typeof useBackofficeCompaniesSuspenseQuery>;
 export type BackofficeCompaniesQueryResult = Apollo.QueryResult<BackofficeCompaniesQuery, BackofficeCompaniesQueryVariables>;
+export const BackofficeCompanyDocument = gql`
+    query BackofficeCompany($id: ID!) {
+  backofficeCompany(id: $id) {
+    id
+    name
+    slug
+    active
+    featureKeys
+  }
+}
+    `;
+
+/**
+ * __useBackofficeCompanyQuery__
+ *
+ * To run a query within a React component, call `useBackofficeCompanyQuery` and pass it any options that fit your needs.
+ * When your component renders, `useBackofficeCompanyQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useBackofficeCompanyQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useBackofficeCompanyQuery(baseOptions: Apollo.QueryHookOptions<BackofficeCompanyQuery, BackofficeCompanyQueryVariables> & ({ variables: BackofficeCompanyQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<BackofficeCompanyQuery, BackofficeCompanyQueryVariables>(BackofficeCompanyDocument, options);
+      }
+export function useBackofficeCompanyLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<BackofficeCompanyQuery, BackofficeCompanyQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<BackofficeCompanyQuery, BackofficeCompanyQueryVariables>(BackofficeCompanyDocument, options);
+        }
+// @ts-ignore
+export function useBackofficeCompanySuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<BackofficeCompanyQuery, BackofficeCompanyQueryVariables>): Apollo.UseSuspenseQueryResult<BackofficeCompanyQuery, BackofficeCompanyQueryVariables>;
+export function useBackofficeCompanySuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<BackofficeCompanyQuery, BackofficeCompanyQueryVariables>): Apollo.UseSuspenseQueryResult<BackofficeCompanyQuery | undefined, BackofficeCompanyQueryVariables>;
+export function useBackofficeCompanySuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<BackofficeCompanyQuery, BackofficeCompanyQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<BackofficeCompanyQuery, BackofficeCompanyQueryVariables>(BackofficeCompanyDocument, options);
+        }
+export type BackofficeCompanyQueryHookResult = ReturnType<typeof useBackofficeCompanyQuery>;
+export type BackofficeCompanyLazyQueryHookResult = ReturnType<typeof useBackofficeCompanyLazyQuery>;
+export type BackofficeCompanySuspenseQueryHookResult = ReturnType<typeof useBackofficeCompanySuspenseQuery>;
+export type BackofficeCompanyQueryResult = Apollo.QueryResult<BackofficeCompanyQuery, BackofficeCompanyQueryVariables>;
 export const BackofficeUsersDocument = gql`
-    query BackofficeUsers($companyId: ID, $offset: Int = 0, $limit: Int = 20) {
-  backofficeUsers(companyId: $companyId, offset: $offset, limit: $limit) {
+    query BackofficeUsers($companyId: ID, $search: String, $offset: Int = 0, $limit: Int = 20) {
+  backofficeUsers(
+    companyId: $companyId
+    search: $search
+    offset: $offset
+    limit: $limit
+  ) {
     totalCount
     items {
       id
@@ -685,6 +835,7 @@ export const BackofficeUsersDocument = gql`
  * const { data, loading, error } = useBackofficeUsersQuery({
  *   variables: {
  *      companyId: // value for 'companyId'
+ *      search: // value for 'search'
  *      offset: // value for 'offset'
  *      limit: // value for 'limit'
  *   },
@@ -709,6 +860,56 @@ export type BackofficeUsersQueryHookResult = ReturnType<typeof useBackofficeUser
 export type BackofficeUsersLazyQueryHookResult = ReturnType<typeof useBackofficeUsersLazyQuery>;
 export type BackofficeUsersSuspenseQueryHookResult = ReturnType<typeof useBackofficeUsersSuspenseQuery>;
 export type BackofficeUsersQueryResult = Apollo.QueryResult<BackofficeUsersQuery, BackofficeUsersQueryVariables>;
+export const BackofficeUserDocument = gql`
+    query BackofficeUser($id: ID!) {
+  backofficeUser(id: $id) {
+    id
+    name
+    surname
+    email
+    language
+    role
+    companyId
+    permissionKeys
+  }
+}
+    `;
+
+/**
+ * __useBackofficeUserQuery__
+ *
+ * To run a query within a React component, call `useBackofficeUserQuery` and pass it any options that fit your needs.
+ * When your component renders, `useBackofficeUserQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useBackofficeUserQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useBackofficeUserQuery(baseOptions: Apollo.QueryHookOptions<BackofficeUserQuery, BackofficeUserQueryVariables> & ({ variables: BackofficeUserQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<BackofficeUserQuery, BackofficeUserQueryVariables>(BackofficeUserDocument, options);
+      }
+export function useBackofficeUserLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<BackofficeUserQuery, BackofficeUserQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<BackofficeUserQuery, BackofficeUserQueryVariables>(BackofficeUserDocument, options);
+        }
+// @ts-ignore
+export function useBackofficeUserSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<BackofficeUserQuery, BackofficeUserQueryVariables>): Apollo.UseSuspenseQueryResult<BackofficeUserQuery, BackofficeUserQueryVariables>;
+export function useBackofficeUserSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<BackofficeUserQuery, BackofficeUserQueryVariables>): Apollo.UseSuspenseQueryResult<BackofficeUserQuery | undefined, BackofficeUserQueryVariables>;
+export function useBackofficeUserSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<BackofficeUserQuery, BackofficeUserQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<BackofficeUserQuery, BackofficeUserQueryVariables>(BackofficeUserDocument, options);
+        }
+export type BackofficeUserQueryHookResult = ReturnType<typeof useBackofficeUserQuery>;
+export type BackofficeUserLazyQueryHookResult = ReturnType<typeof useBackofficeUserLazyQuery>;
+export type BackofficeUserSuspenseQueryHookResult = ReturnType<typeof useBackofficeUserSuspenseQuery>;
+export type BackofficeUserQueryResult = Apollo.QueryResult<BackofficeUserQuery, BackofficeUserQueryVariables>;
 export const BackofficeCreateCompanyDocument = gql`
     mutation BackofficeCreateCompany($input: BackofficeCreateCompanyInput!) {
   backofficeCreateCompany(input: $input) {
@@ -847,8 +1048,13 @@ export type BackofficeCreateTrackerMutationHookResult = ReturnType<typeof useBac
 export type BackofficeCreateTrackerMutationResult = Apollo.MutationResult<BackofficeCreateTrackerMutation>;
 export type BackofficeCreateTrackerMutationOptions = Apollo.BaseMutationOptions<BackofficeCreateTrackerMutation, BackofficeCreateTrackerMutationVariables>;
 export const BackofficeTrackersDocument = gql`
-    query BackofficeTrackers($companyId: ID, $offset: Int = 0, $limit: Int = 20) {
-  backofficeTrackers(companyId: $companyId, offset: $offset, limit: $limit) {
+    query BackofficeTrackers($companyId: ID, $search: String, $offset: Int = 0, $limit: Int = 20) {
+  backofficeTrackers(
+    companyId: $companyId
+    search: $search
+    offset: $offset
+    limit: $limit
+  ) {
     totalCount
     items {
       id
@@ -873,6 +1079,7 @@ export const BackofficeTrackersDocument = gql`
  * const { data, loading, error } = useBackofficeTrackersQuery({
  *   variables: {
  *      companyId: // value for 'companyId'
+ *      search: // value for 'search'
  *      offset: // value for 'offset'
  *      limit: // value for 'limit'
  *   },
@@ -1013,6 +1220,148 @@ export function useBackofficeUpdateUserMutation(baseOptions?: Apollo.MutationHoo
 export type BackofficeUpdateUserMutationHookResult = ReturnType<typeof useBackofficeUpdateUserMutation>;
 export type BackofficeUpdateUserMutationResult = Apollo.MutationResult<BackofficeUpdateUserMutation>;
 export type BackofficeUpdateUserMutationOptions = Apollo.BaseMutationOptions<BackofficeUpdateUserMutation, BackofficeUpdateUserMutationVariables>;
+export const BackofficeDeleteCompanyDocument = gql`
+    mutation BackofficeDeleteCompany($id: ID!) {
+  backofficeDeleteCompany(id: $id) {
+    success
+    message
+  }
+}
+    `;
+export type BackofficeDeleteCompanyMutationFn = Apollo.MutationFunction<BackofficeDeleteCompanyMutation, BackofficeDeleteCompanyMutationVariables>;
+
+/**
+ * __useBackofficeDeleteCompanyMutation__
+ *
+ * To run a mutation, you first call `useBackofficeDeleteCompanyMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useBackofficeDeleteCompanyMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [backofficeDeleteCompanyMutation, { data, loading, error }] = useBackofficeDeleteCompanyMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useBackofficeDeleteCompanyMutation(baseOptions?: Apollo.MutationHookOptions<BackofficeDeleteCompanyMutation, BackofficeDeleteCompanyMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<BackofficeDeleteCompanyMutation, BackofficeDeleteCompanyMutationVariables>(BackofficeDeleteCompanyDocument, options);
+      }
+export type BackofficeDeleteCompanyMutationHookResult = ReturnType<typeof useBackofficeDeleteCompanyMutation>;
+export type BackofficeDeleteCompanyMutationResult = Apollo.MutationResult<BackofficeDeleteCompanyMutation>;
+export type BackofficeDeleteCompanyMutationOptions = Apollo.BaseMutationOptions<BackofficeDeleteCompanyMutation, BackofficeDeleteCompanyMutationVariables>;
+export const BackofficeDeleteUserDocument = gql`
+    mutation BackofficeDeleteUser($id: ID!) {
+  backofficeDeleteUser(id: $id) {
+    success
+    message
+  }
+}
+    `;
+export type BackofficeDeleteUserMutationFn = Apollo.MutationFunction<BackofficeDeleteUserMutation, BackofficeDeleteUserMutationVariables>;
+
+/**
+ * __useBackofficeDeleteUserMutation__
+ *
+ * To run a mutation, you first call `useBackofficeDeleteUserMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useBackofficeDeleteUserMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [backofficeDeleteUserMutation, { data, loading, error }] = useBackofficeDeleteUserMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useBackofficeDeleteUserMutation(baseOptions?: Apollo.MutationHookOptions<BackofficeDeleteUserMutation, BackofficeDeleteUserMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<BackofficeDeleteUserMutation, BackofficeDeleteUserMutationVariables>(BackofficeDeleteUserDocument, options);
+      }
+export type BackofficeDeleteUserMutationHookResult = ReturnType<typeof useBackofficeDeleteUserMutation>;
+export type BackofficeDeleteUserMutationResult = Apollo.MutationResult<BackofficeDeleteUserMutation>;
+export type BackofficeDeleteUserMutationOptions = Apollo.BaseMutationOptions<BackofficeDeleteUserMutation, BackofficeDeleteUserMutationVariables>;
+export const BackofficeDeleteTrackerDocument = gql`
+    mutation BackofficeDeleteTracker($id: ID!) {
+  backofficeDeleteTracker(id: $id) {
+    success
+    message
+  }
+}
+    `;
+export type BackofficeDeleteTrackerMutationFn = Apollo.MutationFunction<BackofficeDeleteTrackerMutation, BackofficeDeleteTrackerMutationVariables>;
+
+/**
+ * __useBackofficeDeleteTrackerMutation__
+ *
+ * To run a mutation, you first call `useBackofficeDeleteTrackerMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useBackofficeDeleteTrackerMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [backofficeDeleteTrackerMutation, { data, loading, error }] = useBackofficeDeleteTrackerMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useBackofficeDeleteTrackerMutation(baseOptions?: Apollo.MutationHookOptions<BackofficeDeleteTrackerMutation, BackofficeDeleteTrackerMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<BackofficeDeleteTrackerMutation, BackofficeDeleteTrackerMutationVariables>(BackofficeDeleteTrackerDocument, options);
+      }
+export type BackofficeDeleteTrackerMutationHookResult = ReturnType<typeof useBackofficeDeleteTrackerMutation>;
+export type BackofficeDeleteTrackerMutationResult = Apollo.MutationResult<BackofficeDeleteTrackerMutation>;
+export type BackofficeDeleteTrackerMutationOptions = Apollo.BaseMutationOptions<BackofficeDeleteTrackerMutation, BackofficeDeleteTrackerMutationVariables>;
+export const BackofficeSetUserPermissionDocument = gql`
+    mutation BackofficeSetUserPermission($id: ID!, $permissionKey: String!, $enabled: Boolean!) {
+  backofficeSetUserPermission(
+    id: $id
+    permissionKey: $permissionKey
+    enabled: $enabled
+  ) {
+    success
+    message
+  }
+}
+    `;
+export type BackofficeSetUserPermissionMutationFn = Apollo.MutationFunction<BackofficeSetUserPermissionMutation, BackofficeSetUserPermissionMutationVariables>;
+
+/**
+ * __useBackofficeSetUserPermissionMutation__
+ *
+ * To run a mutation, you first call `useBackofficeSetUserPermissionMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useBackofficeSetUserPermissionMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [backofficeSetUserPermissionMutation, { data, loading, error }] = useBackofficeSetUserPermissionMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *      permissionKey: // value for 'permissionKey'
+ *      enabled: // value for 'enabled'
+ *   },
+ * });
+ */
+export function useBackofficeSetUserPermissionMutation(baseOptions?: Apollo.MutationHookOptions<BackofficeSetUserPermissionMutation, BackofficeSetUserPermissionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<BackofficeSetUserPermissionMutation, BackofficeSetUserPermissionMutationVariables>(BackofficeSetUserPermissionDocument, options);
+      }
+export type BackofficeSetUserPermissionMutationHookResult = ReturnType<typeof useBackofficeSetUserPermissionMutation>;
+export type BackofficeSetUserPermissionMutationResult = Apollo.MutationResult<BackofficeSetUserPermissionMutation>;
+export type BackofficeSetUserPermissionMutationOptions = Apollo.BaseMutationOptions<BackofficeSetUserPermissionMutation, BackofficeSetUserPermissionMutationVariables>;
 export const GetTrackersDocument = gql`
     query GetTrackers($offset: Int = 0, $limit: Int = 20) {
   trackers(offset: $offset, limit: $limit) {

--- a/track-app/src/graphql/backoffice.gql
+++ b/track-app/src/graphql/backoffice.gql
@@ -18,8 +18,8 @@ query BackofficeCompany($id: ID!) {
   }
 }
 
-query BackofficeUsers($companyId: ID, $offset: Int = 0, $limit: Int = 20) {
-  backofficeUsers(companyId: $companyId, offset: $offset, limit: $limit) {
+query BackofficeUsers($companyId: ID, $search: String, $offset: Int = 0, $limit: Int = 20) {
+  backofficeUsers(companyId: $companyId, search: $search, offset: $offset, limit: $limit) {
     totalCount
     items {
       id
@@ -78,8 +78,8 @@ mutation BackofficeCreateTracker($input: BackofficeCreateTrackerInput!) {
   }
 }
 
-query BackofficeTrackers($companyId: ID, $offset: Int = 0, $limit: Int = 20) {
-  backofficeTrackers(companyId: $companyId, offset: $offset, limit: $limit) {
+query BackofficeTrackers($companyId: ID, $search: String, $offset: Int = 0, $limit: Int = 20) {
+  backofficeTrackers(companyId: $companyId, search: $search, offset: $offset, limit: $limit) {
     totalCount
     items {
       id

--- a/track-app/src/hooks/useBackoffice.ts
+++ b/track-app/src/hooks/useBackoffice.ts
@@ -120,9 +120,13 @@ export function useBackoffice(
     usersPage = 1,
     pageSize = 20,
     enableUsersQuery = true,
+    usersCompanyId?: string,
+    usersSearch = '',
     trackersPage = 1,
     trackersPageSize = 20,
     enableTrackersQuery = false,
+    trackersCompanyId?: string,
+    trackersSearch = '',
     trackerId?: string,
     companyId?: string,
     userId?: string
@@ -138,14 +142,19 @@ export function useBackoffice(
         fetchPolicy: 'cache-and-network',
         errorPolicy: 'all',
         skip: !enableUsersQuery,
-        variables: { offset, limit: pageSize },
+        variables: { offset, limit: pageSize, companyId: usersCompanyId || undefined, search: usersSearch || undefined },
         onError: (err) => toast.error(err.message)
     })
     const trackersQuery = useBackofficeTrackersQuery({
         fetchPolicy: 'cache-and-network',
         errorPolicy: 'all',
         skip: !enableTrackersQuery,
-        variables: { offset: trackersOffset, limit: trackersPageSize },
+        variables: {
+            offset: trackersOffset,
+            limit: trackersPageSize,
+            companyId: trackersCompanyId || undefined,
+            search: trackersSearch || undefined
+        },
         onError: (err) => toast.error(err.message)
     })
     const trackerDetailQuery = useBackofficeTrackerQuery({

--- a/track-app/src/locales/ca/common.json
+++ b/track-app/src/locales/ca/common.json
@@ -177,6 +177,8 @@
     "slug": "Slug",
     "selectCompany": "Selecciona una companyia",
     "selectCompanyShort": "Selecciona companyia",
+    "allCompanies": "Totes les companyies",
+    "searchPlaceholder": "Cercar text...",
     "selectUser": "Selecciona usuari",
     "language": "Idioma",
     "noCompanies": "Encara no hi ha companyies.",

--- a/track-app/src/locales/en/common.json
+++ b/track-app/src/locales/en/common.json
@@ -177,6 +177,8 @@
     "slug": "Slug",
     "selectCompany": "Select a company",
     "selectCompanyShort": "Select company",
+    "allCompanies": "All companies",
+    "searchPlaceholder": "Search text...",
     "selectUser": "Select user",
     "language": "Language",
     "noCompanies": "No companies yet.",

--- a/track-app/src/locales/es/common.json
+++ b/track-app/src/locales/es/common.json
@@ -177,6 +177,8 @@
     "slug": "Slug",
     "selectCompany": "Selecciona una compañía",
     "selectCompanyShort": "Selecciona compañía",
+    "allCompanies": "Todas las compañías",
+    "searchPlaceholder": "Buscar por texto...",
     "selectUser": "Selecciona usuario",
     "language": "Idioma",
     "noCompanies": "Aún no hay compañías.",


### PR DESCRIPTION
## Resumen
- añade filtros en tablas de backoffice
- incorpora filtro por company en users/trackers
- incorpora búsqueda por texto para filtrar datos
- actualiza GraphQL (schema, queries y tipos generados)

## Cambios técnicos
- backend: backofficeUsers y backofficeTrackers aceptan search y aplican filtro server-side
- frontend: UI de filtros + search, debounce y reset de paginación al cambiar filtros
- i18n: nuevas etiquetas para filtros y placeholder de búsqueda

## Validación
- npm run typecheck -w track-app
- npm test -w track-api
- npm test -w track-app